### PR TITLE
Fix a compile error: Sprintf format %s has arg pnum of wrong type uint16

### DIFF
--- a/internal/app/master/inspectors/container/probes/http/custom_probe.go
+++ b/internal/app/master/inspectors/container/probes/http/custom_probe.go
@@ -84,7 +84,7 @@ func NewCustomProbe(inspector *container.Inspector,
 			pspec := dockerapi.Port(fmt.Sprintf("%v/tcp", pnum))
 			if _, ok := inspector.ContainerInfo.NetworkSettings.Ports[pspec]; ok {
 				if inspector.InContainer {
-					probe.Ports = append(probe.Ports, fmt.Sprintf("%s", pnum))
+					probe.Ports = append(probe.Ports, fmt.Sprintf("%d", pnum))
 				} else {
 					probe.Ports = append(probe.Ports, inspector.ContainerInfo.NetworkSettings.Ports[pspec][0].HostPort)
 				}


### PR DESCRIPTION
```
$ GOOS=linux go vet ./...
 # github.com/docker-slim/docker-slim/internal/app/master/inspectors/container/probes/http
internal/app/master/inspectors/container/probes/http/custom_probe.go:87:40: Sprintf format %s has arg pnum of wrong type uint16
```