### PR TITLE
replaced info with containerize command on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Commands:
 - `xray` - Collects fat image information and reverse engineers its Dockerfile
 - `build` - Collect fat image information and build a slim image from it
 - `profile` - Collect fat image information and generate a fat container report
-- `info` - Collect fat image information and reverse engineers its Dockerfile (no runtime container analysis)
+- `containerize` - Containerize the target artifacts
 - `version` - Show docker-slim and docker version information
 - `update` - Update docker-slim
 - `help` - Show help info


### PR DESCRIPTION
Because not exist `info` command. but we can use `containerize` command.

```
$ docker-slim help
Incorrect Usage. flag: help requested

NAME:
   docker-slim - optimize and secure your Docker containers!

USAGE:
   docker-slim [global options] command [command options] [arguments...]

VERSION:
   darwin|Transformer|1.29.0|afff2c9679a697ebfc933360267253a10325269d|2020-03-18_07:11:20PM

COMMANDS:
   help, h          Show help info
   version, v       Shows docker-slim and docker version information
   update, u        Updates docker-slim
   containerize, c  Containerize the target artifacts
   lint, l          Lint the target Dockerfile or image
   xray, x          Collects fat image information and reverse engineers its Dockerfile
   build, b         Collects fat image information and builds a slim image from it
   profile, p       Collects fat image information and generates a fat container report

GLOBAL OPTIONS:
   --report value         command report location (enabled by default; set it to "off" to disable it) (default: "slim.report.json")
   --check-version        check if the current version is outdated [$DSLIM_CHECK_VERSION]
   --debug                enable debug logs
   --verbose              enable info logs
   --log-level value      set the logging level ('debug', 'info', 'warn' (default), 'error', 'fatal', 'panic') (default: "warn")
   --log value            log file to store logs
   --log-format value     set the format used by logs ('text' (default), or 'json') (default: "text")
   --tls                  use TLS
   --tls-verify           verify TLS
   --tls-cert-path value  path to TLS cert files
   --host value           Docker host address
   --state-path value     DockerSlim state base path
   --in-container         DockerSlim is running in a container
   --archive-state value  archive DockerSlim state to the selected Docker volume (default volume - docker-slim-state). By default, enabled when DockerSlim is running in a container (disabled otherwise). Set it to "off" to disable explicitly.
   --version, -v          print the version
```