### PR TITLE
Force the host user namespace to be used

### DIFF
--- a/internal/app/master/inspectors/container/container_inspector.go
+++ b/internal/app/master/inspectors/container/container_inspector.go
@@ -304,6 +304,7 @@ func (i *Inspector) RunContainer() error {
 			PublishAllPorts: true, //TODO: need a command flag for this option
 			CapAdd:          []string{"SYS_ADMIN"},
 			Privileged:      true,
+			UsernsMode:      "host",
 		},
 	}
 


### PR DESCRIPTION
When running the child container with privileged mode, the user
namespace must be set to "host", otherwise docker will fail with the
error "API error (400): privileged mode is incompatible with user
namespaces. You must run the container in the host namespace when running
privileged mode"