### PR TITLE
add a quick build script for linux amd64 to get a faster iteration cycle

### DIFF
--- a/scripts/src.build.quick.sh
+++ b/scripts/src.build.quick.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
+BDIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
+
+mkdir -p ${BDIR}/dist_linux/
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -o "${BDIR}/dist_linux/docker-slim" "${BDIR}/cmd/docker-slim/main.go"


### PR DESCRIPTION
the current build scripts takes a long time and builds many things. the typical development cycle is to build one thing as quickly as possible, and this script makes that much faster. 