### PR TITLE
add self documenting make support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,25 @@
-default: build_in_docker
+default: build_in_docker ## build docker-slim in docker by default
 
-build_in_docker:
+build_in_docker:   ## build docker-slim in docker
 	rm -rfv bin
 	'$(CURDIR)/scripts/docker-builder.run.sh'
 
-build:
+build:  ## build docker-slim
 	'$(CURDIR)/scripts/src.build.sh'
 
-fmt:
+fmt:  ## format all golang files
 	'$(CURDIR)/scripts/src.fmt.sh'
 
-inspect:
+help: ## prints out the menu of command options
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+inspect: ## report suspicious constructs and linting errors
 	'$(CURDIR)/scripts/src.inspect.sh'
 
-tools:
+tools: ## install necessary tools
 	'$(CURDIR)/scripts/tools.get.sh'
 
-clean:
+clean: ## clean up
 	'$(CURDIR)/scripts/src.cleanup.sh'
 
-.PHONY: default build_in_docker build fmt inspect tools clean
+.PHONY: default help build_in_docker build fmt inspect tools clean


### PR DESCRIPTION
What
=================
* Add self documenting support to makefile

Why
=================
* make it easier to use the makefile directly without looking for README info (docs close to code)

How tested
=================
Manually output:

```bash
➜  docker-slim git:(makefile-update) make help
build                          build docker-slim
build_in_docker                build docker-slim in docker
clean                          clean up
default                        build docker-slim in docker by default
fmt                            format all golang files
help                           prints out the menu of command options
inspect                        report suspicious constructs and linting errors
tools                          install necessary tools

```
