### PR TITLE
exit non-zero for more build errors

### DIFF
--- a/internal/app/master/commands/build/handler.go
+++ b/internal/app/master/commands/build/handler.go
@@ -200,7 +200,7 @@ func OnCommand(
 	if imageInspector.NoImage() {
 		fmt.Printf("cmd=%s info=target.image.error status=not.found image='%v' message='make sure the target image already exists locally'\n", cmdName, targetRef)
 		fmt.Printf("cmd=%s state=exited\n", cmdName)
-		return
+		commands.Exit(commands.ECTBuild | ecbImageBuildError)
 	}
 
 	fmt.Printf("cmd=%s state=image.inspection.start\n", cmdName)
@@ -332,7 +332,7 @@ func OnCommand(
 			_ = containerInspector.ShutdownContainer()
 
 			fmt.Printf("cmd=%s state=exited\n", cmdName)
-			return
+			commands.Exit(commands.ECTBuild | ecbImageBuildError)
 		}
 
 		probe.Start()

--- a/scripts/src.build.quick.sh
+++ b/scripts/src.build.quick.sh
@@ -6,5 +6,18 @@ SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
 BDIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
 
+BUILD_TIME="$(date -u '+%Y-%m-%d_%I:%M:%S%p')"
+TAG="current"
+REVISION="current"
+if hash git 2>/dev/null && [ -e $BDIR/.git ]; then
+  TAG="$(git describe --tags)"
+  REVISION="$(git rev-parse HEAD)"
+fi
+
+LD_FLAGS="-s -w -X github.com/docker-slim/docker-slim/pkg/version.appVersionTag=${TAG} -X github.com/docker-slim/docker-slim/pkg/version.appVersionRev=${REVISION} -X github.com/docker-slim/docker-slim/pkg/version.appVersionTime=${BUILD_TIME}"
+
 mkdir -p ${BDIR}/dist_linux/
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -o "${BDIR}/dist_linux/docker-slim" "${BDIR}/cmd/docker-slim/main.go"
+rm -f ${BDIR}/dist_linux/*
+
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="${LD_FLAGS}" -mod=vendor -o "${BDIR}/dist_linux/docker-slim" "${BDIR}/cmd/docker-slim/main.go"
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="${LD_FLAGS}" -mod=vendor -o "${BDIR}/dist_linux/docker-slim-sensor" "${BDIR}/cmd/docker-slim-sensor/main.go"


### PR DESCRIPTION
==================================================================

What
===============
docker-slim exits 0 on a few error cases for build.

```bash
docker pull python
docker-slim build python
echo $?
0
```

Why
===============

errors should exit non-zero

How Tested
===============

```bash
docker pull python
docker-slim build python
echo $?
3
```


