### PR TITLE
remove double slashes from slim report output

### DIFF
--- a/pkg/docker/dockerimage/dockerimage.go
+++ b/pkg/docker/dockerimage/dockerimage.go
@@ -589,6 +589,9 @@ func layerFromStream(layerPath string,
 			object.Name = fmt.Sprintf("/%s", normalized)
 		}
 
+		object.Name = strings.ReplaceAll(object.Name, "//", "/")
+		object.LinkTarget = strings.ReplaceAll(object.LinkTarget, "//", "/")
+
 		if isDeletedDirContent {
 			object.DirContentDelete = true
 		}


### PR DESCRIPTION
when running the following xray:

`docker-slim xray cloudfoundry/cnb --changes-output=report --changes=all`

i noticed the following output:

```
>> cat slim.report.json |grep '/cnb'|head -n100 | tail -n10
          "name": "//cnb/buildpacks/paketo-buildpacks_procfile/4.1.0/bin/main",
          "name": "//cnb/buildpacks/paketo-buildpacks_procfile/4.1.0/bin/main.exe",
          "name": "//cnb/buildpacks/paketo-buildpacks_procfile/4.1.0/buildpack.toml",
          "name": "//cnb/buildpacks/paketo-buildpacks_dotnet-core-aspnet/0.1.10/bin/run",
          "name": "//cnb/buildpacks/paketo-buildpacks_dotnet-core-aspnet/0.1.10/buildpack.toml",
          "name": "//cnb/buildpacks/paketo-buildpacks_dotnet-core-aspnet/0.1.10/bin",
          "name": "//cnb/buildpacks/paketo-buildpacks_dotnet-core-aspnet/0.1.10/bin/detect",
          "name": "//cnb/buildpacks/paketo-buildpacks_dotnet-core-aspnet/0.1.10/bin/build",
          "name": "//cnb/buildpacks/paketo-buildpacks_dotnet-core-aspnet/0.1.10",
          "name": "//cnb/buildpacks/paketo-buildpacks_dotnet-core-aspnet",

```

this pr changes the output to:

```
>> cat slim.report.json |grep '/cnb'|head -n100 | tail -n10
          "name": "/cnb/buildpacks/paketo-buildpacks_procfile/4.1.0/bin/main",
          "name": "/cnb/buildpacks/paketo-buildpacks_procfile/4.1.0/bin/main.exe",
          "name": "/cnb/buildpacks/paketo-buildpacks_procfile/4.1.0/buildpack.toml",
          "name": "/cnb/buildpacks/paketo-buildpacks_dotnet-core-aspnet/0.1.10/bin/run",
          "name": "/cnb/buildpacks/paketo-buildpacks_dotnet-core-aspnet/0.1.10/buildpack.toml",
          "name": "/cnb/buildpacks/paketo-buildpacks_dotnet-core-aspnet/0.1.10/bin",
          "name": "/cnb/buildpacks/paketo-buildpacks_dotnet-core-aspnet/0.1.10/bin/detect",
          "name": "/cnb/buildpacks/paketo-buildpacks_dotnet-core-aspnet/0.1.10/bin/build",
          "name": "/cnb/buildpacks/paketo-buildpacks_dotnet-core-aspnet/0.1.10",
          "name": "/cnb/buildpacks/paketo-buildpacks_dotnet-core-aspnet",

```


