### PR TITLE
fix tiny typo in subject-verb agreement

### DIFF
--- a/pkg/app/master/version/version.go
+++ b/pkg/app/master/version/version.go
@@ -62,7 +62,7 @@ func GetCheckVersionVerdict(info *CheckVersionInfo) string {
 		if info.Outdated {
 			return fmt.Sprintf("your installed version is OUTDATED (local=%s current=%s)", v.Tag(), info.Current)
 		} else {
-			return "your have the latest version"
+			return "you have the latest version"
 		}
 	}
 


### PR DESCRIPTION
What
===============
Fixes minor typo in version-checker output. Currently, if you run `docker-slim version` and `docker-slim` is up to date, the output is "your have the latest version". This PR changes "your" to "you".

Why
===============
I happened to notice while I was checking the version, and I'm a weirdo about grammar.

How Tested
===============
I built the Mac version locally and ran `docker-slim`

