### PR TITLE
default continue-after mode to exec when exec specified and continue-after mode not specified

### DIFF
--- a/pkg/app/master/commands/build/cli.go
+++ b/pkg/app/master/commands/build/cli.go
@@ -484,7 +484,7 @@ var CLI = cli.Command{
 			errutil.FailOn(err)
 
 			if !strings.Contains(continueAfter.Mode, config.CAMExec) {
-				continueAfter.Mode = fmt.Sprintf("%s&%s", continueAfter.Mode, config.CAMExec)
+				continueAfter.Mode = config.CAMExec
 				xc.Out.Info("exec",
 					ovars{
 						"message": fmt.Sprintf("updating continue-after mode to %s", continueAfter.Mode),
@@ -493,7 +493,7 @@ var CLI = cli.Command{
 
 		} else if len(execCmd) > 0 {
 			if !strings.Contains(continueAfter.Mode, config.CAMExec) {
-				continueAfter.Mode = fmt.Sprintf("%s&%s", continueAfter.Mode, config.CAMExec)
+				continueAfter.Mode = config.CAMExec
 				xc.Out.Info("exec",
 					ovars{
 						"message": fmt.Sprintf("updating continue-after mode to %s", continueAfter.Mode),


### PR DESCRIPTION
After updating to 1.36, i cannot use `--exec` without also using `--continue-after exec`, even when using `--http-probe=false`.

This diff defaults `--continue-after` to `exec` when using `--exec`.