### PR TITLE
Allow parsing host options from JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,6 @@ In the interactive CLI prompt mode you must specify the target image using the `
 - `--path-perms-file` - File with path permissions to set (format: `target:octalPermFlags#uid#gid` ; see the non-default USER FAQ section for more details)
 - `--exclude-pattern` - Exclude path pattern ([Glob/Match in Go](https://golang.org/pkg/path/filepath/#Match) and `**`) from image
 - `--exclude-mounts` - Exclude mounted volumes from image (default value: true)
-- `--env` - Override or add ENV analyzing image at runtime [can use this flag multiple times]
 - `--label` - Override or add LABEL analyzing image at runtime [can use this flag multiple times]
 - `--volume` - Add VOLUME analyzing image at runtime [can use this flag multiple times]
 - `--env` - Override ENV analyzing image at runtime [can use this flag multiple times]
@@ -408,6 +407,7 @@ In the interactive CLI prompt mode you must specify the target image using the `
 - `--cbo-network` - Networking mode to use for the RUN instructions at build-time (Container Build Option).
 - `--cbo-cache-from` - Add an image to the build cache (Container Build Option).
 - `--cro-runtime` - Runtime to use with the created containers (Container Runtime Option).
+- `--cro-host-config-file` - Base Docker host configuration file (JSON format) to use when running the container. See [here](https://pkg.go.dev/github.com/fsouza/go-dockerclient#HostConfig) for configuration details. Note that docker-slim will automatically add `SYS_ADMIN` to the list of capabilities and run the container in privileged mode, which are required to generate the seccomp profiles.
 - `--use-local-mounts` - Mount local paths for target container artifact input and output (off, by default)
 - `--use-sensor-volume` - Sensor volume name to use (set it to your Docker volume name if you manage your own `docker-slim` sensor volume).
 - `--keep-tmp-artifacts` - Keep temporary artifacts when command is done (off, by default).

--- a/pkg/app/master/commands/build/cli.go
+++ b/pkg/app/master/commands/build/cli.go
@@ -64,6 +64,7 @@ var CLI = cli.Command{
 		//Container Run Options
 		commands.Cflag(commands.FlagCRORuntime),
 		commands.Cflag(commands.FlagCROSysctl),
+		commands.Cflag(commands.FlagCROHostConfigFile),
 		commands.Cflag(commands.FlagEntrypoint),
 		commands.Cflag(commands.FlagCmd),
 		commands.Cflag(commands.FlagWorkdir),

--- a/pkg/app/master/commands/common.go
+++ b/pkg/app/master/commands/common.go
@@ -109,6 +109,7 @@ const (
 	//Container Run Options (for build, profile and run commands)
 	FlagCRORuntime = "cro-runtime"
 	FlagCROSysctl  = "cro-sysctl"
+	FlagCROHostConfigFile  = "cro-host-config-file"
 
 	//Original Container Runtime Options (without cro- prefix)
 	FlagEntrypoint         = "entrypoint"
@@ -173,6 +174,7 @@ const (
 	//Container Run Options (for build, profile and run commands)
 	FlagCRORuntimeUsage = "Runtime to use with the created containers"
 	FlagCROSysctlUsage  = "Set namespaced kernel parameters in the created container"
+	FlagCROHostConfigFileUsage  = "Base Docker host configuration file (JSON format) to use when running the container"
 
 	FlagEntrypointUsage         = "Override ENTRYPOINT analyzing image at runtime"
 	FlagCmdUsage                = "Override CMD analyzing image at runtime"
@@ -469,6 +471,12 @@ var CommonFlags = map[string]cli.Flag{
 		Value:  &cli.StringSlice{},
 		Usage:  FlagCROSysctlUsage,
 		EnvVar: "DSLIM_CRO_SYSCTL",
+	},
+	FlagCROHostConfigFile: cli.StringFlag{
+		Name:   FlagCROHostConfigFile,
+		Value:  "",
+		Usage:  FlagCROHostConfigFileUsage,
+		EnvVar: "DSLIM_CRO_HOST_CONFIG_FILE",
 	},
 	FlagEntrypoint: cli.StringFlag{
 		Name:   FlagEntrypoint,

--- a/pkg/app/master/commands/profile/cli.go
+++ b/pkg/app/master/commands/profile/cli.go
@@ -50,6 +50,7 @@ var CLI = cli.Command{
 		commands.Cflag(commands.FlagRemoveFileArtifacts),
 		//Container Run Options
 		commands.Cflag(commands.FlagCRORuntime),
+		commands.Cflag(commands.FlagCROHostConfigFile),
 		//
 		commands.Cflag(commands.FlagEntrypoint),
 		commands.Cflag(commands.FlagCmd),

--- a/pkg/app/master/config/config.go
+++ b/pkg/app/master/config/config.go
@@ -63,6 +63,7 @@ type CBOBuildArg struct {
 type ContainerRunOptions struct {
 	Runtime      string
 	SysctlParams map[string]string
+	HostConfig   docker.HostConfig
 }
 
 // VolumeMount provides the volume mount configuration information


### PR DESCRIPTION
What
===============
Adds the ability to parse Docker host configurations from a JSON file.

Why
===============
This lets us specify options like shared memory size, additional capabilities, memory size, etc. that cannot be configured using the docker-slim command line

How Tested
===============
host-config.json:
```json
{
    "ShmSize": 1073741824,
    "Memory": 2147483648,
    "CapAdd": ["WAKE_ALARM"],
    "PublishAllPorts": true
}
```

```shell
% ./dist_mac/docker-slim build --target python:3.9.5-buster --http-probe=false --exec "df /dev/shm" 
docker-slim: message='join the Gitter channel to ask questions or to share your feedback' info='https://gitter.im/docker-slim/community'
docker-slim: message='join the Discord server to ask questions or to share your feedback' info='https://discord.gg/9tDyxYS'
docker-slim: message='Github discussions' info='https://github.com/docker-slim/docker-slim/discussions'
cmd=build info=exec message='changing continue-after from probe to nothing because http-probe is disabled' 
cmd=build info=exec message='updating continue-after mode to exec' 
cmd=build state=started
cmd=build info=params keep.perms='true' tags='' target='python:3.9.5-buster' continue.mode='exec' rt.as.user='true' 
cmd=build state=image.inspection.start
cmd=build info=image id='sha256:9b0d330dfd02b60939072b19a42eedf31064bc32ae642d4fca7468778421c787' size.bytes='885904109' size.human='886 MB' 
cmd=build info=image.stack index='0' name='python:3.9.5-buster' id='sha256:9b0d330dfd02b60939072b19a42eedf31064bc32ae642d4fca7468778421c787' 
cmd=build state=image.inspection.done
cmd=build state=container.inspection.start
cmd=build info=container status='created' name='dockerslimk_31486_20210701223428' id='05e5f9d0d65bfc2d66c64b4641d7e8b3c77b4a890f779c38cf0b8dbeeeaaa9a0' 
cmd=build info=cmd.startmonitor status='sent' 
cmd=build info=event.startmonitor.done status='received' 
cmd=build info=container name='dockerslimk_31486_20210701223428' id='05e5f9d0d65bfc2d66c64b4641d7e8b3c77b4a890f779c38cf0b8dbeeeaaa9a0' target.port.list='' target.port.info='' message='YOU CAN USE THESE PORTS TO INTERACT WITH THE CONTAINER' 
cmd=build info=continue.after message='provide the expected input to allow the container inspector to continue its execution' mode='exec' 
cmd=build info=continue.after mode='exec' shell='df /dev/shm' 
docker-slim[build][exec]: output: Filesystem     1K-blocks  Used Available Use% Mounted on
docker-slim[build][exec]: output: shm                65536     0     65536   0% /dev/shm
cmd=build info=continue.after mode='exec' exitcode='0' 
cmd=build state=container.inspection.finishing
cmd=build state=container.inspection.artifact.processing
cmd=build state=container.inspection.done
cmd=build state=building message=building optimized image 
cmd=build state=completed
cmd=build info=results size.original='886 MB' size.optimized='28 MB' status='MINIFIED' by='32.24X' 
cmd=build info=results image.name='python.slim' image.size='28 MB' has.data='true' 
cmd=build info=results artifacts.location='/Users/jgibson/workspace/docker-slim/dist_mac/.docker-slim-state/images/9b0d330dfd02b60939072b19a42eedf31064bc32ae642d4fca7468778421c787/artifacts' 
cmd=build info=results artifacts.report='creport.json' 
cmd=build info=results artifacts.dockerfile.reversed='Dockerfile.fat' 
cmd=build info=results artifacts.dockerfile.optimized='Dockerfile' 
cmd=build info=results artifacts.seccomp='python-seccomp.json' 
cmd=build info=results artifacts.apparmor='python-apparmor-profile' 
cmd=build state=done
cmd=build info=commands message='use the xray command to learn more about the optimize image' 
cmd=build info=version status='OUTDATED' local='1.36.1-4-gf5ae1f1' current='1.36.1' 
cmd=build message='Your version of DockerSlim is out of date! Use the "update" command or download the new version from https://dockersl.im/downloads.html'
cmd=build info=report file='slim.report.json' 
docker-slim: message='join the Gitter channel to ask questions or to share your feedback' info='https://gitter.im/docker-slim/community'
docker-slim: message='join the Discord server to ask questions or to share your feedback' info='https://discord.gg/9tDyxYS'
docker-slim: message='Github discussions' info='https://github.com/docker-slim/docker-slim/discussions'


% ./dist_mac/docker-slim build --target python:3.9.5-buster --http-probe=false --exec "df /dev/shm" --cro-host-config-file host-options.json
docker-slim: message='join the Gitter channel to ask questions or to share your feedback' info='https://gitter.im/docker-slim/community'
docker-slim: message='join the Discord server to ask questions or to share your feedback' info='https://discord.gg/9tDyxYS'
docker-slim: message='Github discussions' info='https://github.com/docker-slim/docker-slim/discussions'
cmd=build info=exec message='changing continue-after from probe to nothing because http-probe is disabled' 
cmd=build info=exec message='updating continue-after mode to exec' 
cmd=build state=started
cmd=build info=params target='python:3.9.5-buster' continue.mode='exec' rt.as.user='true' keep.perms='true' tags='' 
cmd=build state=image.inspection.start
cmd=build info=image id='sha256:9b0d330dfd02b60939072b19a42eedf31064bc32ae642d4fca7468778421c787' size.bytes='885904109' size.human='886 MB' 
cmd=build info=image.stack index='0' name='python:3.9.5-buster' id='sha256:9b0d330dfd02b60939072b19a42eedf31064bc32ae642d4fca7468778421c787' 
cmd=build state=image.inspection.done
cmd=build state=container.inspection.start
cmd=build info=container id='03a12c4be96ceab6bd6fcb5d33a9ed634fee1b0e7539bdf74e897650537b08a1' status='created' name='dockerslimk_31516_20210701223451' 
cmd=build info=cmd.startmonitor status='sent' 
cmd=build info=event.startmonitor.done status='received' 
cmd=build info=container target.port.list='' target.port.info='' message='YOU CAN USE THESE PORTS TO INTERACT WITH THE CONTAINER' name='dockerslimk_31516_20210701223451' id='03a12c4be96ceab6bd6fcb5d33a9ed634fee1b0e7539bdf74e897650537b08a1' 
cmd=build info=continue.after mode='exec' message='provide the expected input to allow the container inspector to continue its execution' 
cmd=build info=continue.after shell='df /dev/shm' mode='exec' 
docker-slim[build][exec]: output: Filesystem     1K-blocks  Used Available Use% Mounted on
docker-slim[build][exec]: output: shm              1048576     0   1048576   0% /dev/shm
cmd=build info=continue.after mode='exec' exitcode='0' 
cmd=build state=container.inspection.finishing
cmd=build state=container.inspection.artifact.processing
cmd=build state=container.inspection.done
cmd=build state=building message=building optimized image 
cmd=build state=completed
cmd=build info=results status='MINIFIED' by='32.24X' size.original='886 MB' size.optimized='28 MB' 
cmd=build info=results image.name='python.slim' image.size='28 MB' has.data='true' 
cmd=build info=results artifacts.location='/Users/jgibson/workspace/docker-slim/dist_mac/.docker-slim-state/images/9b0d330dfd02b60939072b19a42eedf31064bc32ae642d4fca7468778421c787/artifacts' 
cmd=build info=results artifacts.report='creport.json' 
cmd=build info=results artifacts.dockerfile.reversed='Dockerfile.fat' 
cmd=build info=results artifacts.dockerfile.optimized='Dockerfile' 
cmd=build info=results artifacts.seccomp='python-seccomp.json' 
cmd=build info=results artifacts.apparmor='python-apparmor-profile' 
cmd=build state=done
cmd=build info=commands message='use the xray command to learn more about the optimize image' 
cmd=build info=version status='OUTDATED' local='1.36.1-4-gf5ae1f1' current='1.36.1' 
cmd=build message='Your version of DockerSlim is out of date! Use the "update" command or download the new version from https://dockersl.im/downloads.html'
cmd=build info=report file='slim.report.json' 
docker-slim: message='join the Gitter channel to ask questions or to share your feedback' info='https://gitter.im/docker-slim/community'
docker-slim: message='join the Discord server to ask questions or to share your feedback' info='https://discord.gg/9tDyxYS'
docker-slim: message='Github discussions' info='https://github.com/docker-slim/docker-slim/discussions'
```
verifying that the shared memory size has been changed; this can be repeated to check the other options in various ways