### PR TITLE
fixes variable `parts` index

### DIFF
--- a/pkg/app/master/commands/build/flags.go
+++ b/pkg/app/master/commands/build/flags.go
@@ -308,10 +308,10 @@ func GetContainerBuildOptions(ctx *cli.Context) (*config.ContainerBuildOptions, 
 		if len(parts) == 2 {
 			if strings.HasPrefix(parts[0], "\"") {
 				parts[0] = strings.Trim(parts[0], "\"")
-				parts[1] = strings.Trim(parts[0], "\"")
+				parts[1] = strings.Trim(parts[1], "\"")
 			} else {
 				parts[0] = strings.Trim(parts[0], "'")
-				parts[1] = strings.Trim(parts[0], "'")
+				parts[1] = strings.Trim(parts[1], "'")
 			}
 			ba := config.CBOBuildArg{
 				Name:  parts[0],
@@ -328,10 +328,10 @@ func GetContainerBuildOptions(ctx *cli.Context) (*config.ContainerBuildOptions, 
 		if len(parts) == 2 {
 			if strings.HasPrefix(parts[0], "\"") {
 				parts[0] = strings.Trim(parts[0], "\"")
-				parts[1] = strings.Trim(parts[0], "\"")
+				parts[1] = strings.Trim(parts[1], "\"")
 			} else {
 				parts[0] = strings.Trim(parts[0], "'")
-				parts[1] = strings.Trim(parts[0], "'")
+				parts[1] = strings.Trim(parts[1], "'")
 			}
 
 			cbo.Labels[parts[0]] = parts[1]


### PR DESCRIPTION
Fix
===============
Fixes the index of the variable `parts`. Without the fix, arguments passed in the following way `--cbo-build-arg 'NAME'='VALUE'` would be `NAME=NAME`. With the correction it gets `NAME=VALUE`, as expected.