### PR TITLE
detect utf8 should allow excluding files from tarball above a max size

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ To disable the version checks set the global `--check-version` flag to `false` (
 - `--hash-data` - Generate file data hashes (default: false).
 - `--detect-duplicates` - Detect duplicate files based on their hashes (default: false).
 - `--show-duplicates` - Show all discovered duplicate file paths (default: true).
-- `--detect-utf8` - Detect utf8 files and optionally extract the discovered utf8 file content (possible values: "true" or "dump" or "dump:output_target.tgz" or "dump:output_target.tgz:max_size_bytes").
+- `--detect-utf8` - Detect utf8 files and optionally extract the discovered utf8 file content (possible values: "true" or "dump" or "dump:output_target.tgz" or "dump:output_target.tgz::max_size_bytes" or "dump:output_target.tgz:::max_size_bytes").
 - `--change-match-layers-only` - Show only layers with change matches (default: false).
 - `--remove-file-artifacts` - Remove file artifacts when command is done (note: you'll loose the reverse engineered Dockerfile)
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ To disable the version checks set the global `--check-version` flag to `false` (
 - `--target` - Target container image (name or ID)
 - `--pull` - Try pulling target if it's not available locally (default: false).
 - `--show-plogs` - Show image pull logs (default: false).
-- `--changes value` - Show layer change details for the selected change type (values: none, all, delete, modify, add). 
+- `--changes value` - Show layer change details for the selected change type (values: none, all, delete, modify, add).
 - `--changes-output value` - Where to show the changes (values: all, report, console).
 - `--layer value` - Show details for the selected layer (using layer index or ID)
 - `--add-image-manifest` - Add raw image manifest to the command execution report file
@@ -333,7 +333,7 @@ To disable the version checks set the global `--check-version` flag to `false` (
 - `--hash-data` - Generate file data hashes (default: false).
 - `--detect-duplicates` - Detect duplicate files based on their hashes (default: false).
 - `--show-duplicates` - Show all discovered duplicate file paths (default: true).
-- `--detect-utf8` - Detect utf8 files and optionally extract the discovered utf8 file content (possible values: "true" or "dump" or "dump:output_target").
+- `--detect-utf8` - Detect utf8 files and optionally extract the discovered utf8 file content (possible values: "true" or "dump" or "dump:output_target.tgz" or "dump:output_target.tgz:max_size_bytes").
 - `--change-match-layers-only` - Show only layers with change matches (default: false).
 - `--remove-file-artifacts` - Remove file artifacts when command is done (note: you'll loose the reverse engineered Dockerfile)
 
@@ -874,7 +874,7 @@ Some of the advanced analysis options require a number of Linux kernel features 
 - Build/use a custom Boot2docker kernel with every required feature turned on.
 - "Live" image create mode - to create new images from containers where users install their applications interactively.
 
-The [`WISHLIST`](WISHLIST.md) doc includes even more potential improvements. 
+The [`WISHLIST`](WISHLIST.md) doc includes even more potential improvements.
 
 ## ORIGINS
 

--- a/pkg/app/master/commands/xray/cli.go
+++ b/pkg/app/master/commands/xray/cli.go
@@ -421,13 +421,28 @@ func parseDetectUTF8(ctx *cli.Context) (*dockerimage.UTF8Detector, error) {
 		if len(outTarget) == 0 || outTarget == dockerimage.CDMDumpToConsole {
 			detector.DumpConsole = true
 		} else {
-			if strings.Contains(outTarget, ":") {
-				parts = strings.SplitN(outTarget, ":", 2)
-				if len(parts) != 2 {
+			if strings.Count(outTarget, ":") == 2 {
+				parts = strings.SplitN(outTarget, ":", 3)
+				if len(parts) != 3 {
 					return nil, fmt.Errorf("malformed find utf8: %s", raw)
 				}
 				outTarget = parts[0]
-				maxSizeBytes := parts[1]
+				_ = parts[1] // TODO implemement path pattern matcher
+				maxSizeBytes := parts[2]
+				var err error
+				detector.MaxSizeBytes, err = strconv.Atoi(maxSizeBytes)
+				if err != nil {
+					return nil, err
+				}
+			} else if strings.Count(outTarget, ":") == 3 {
+				parts = strings.SplitN(outTarget, ":", 4)
+				if len(parts) != 4 {
+					return nil, fmt.Errorf("malformed find utf8: %s", raw)
+				}
+				outTarget = parts[0]
+				_ = parts[1] // TODO implemement path pattern matcher
+				_ = parts[2] // TODO implemement data regex matcher
+				maxSizeBytes := parts[3]
 				var err error
 				detector.MaxSizeBytes, err = strconv.Atoi(maxSizeBytes)
 				if err != nil {

--- a/pkg/app/master/commands/xray/cli.go
+++ b/pkg/app/master/commands/xray/cli.go
@@ -2,6 +2,7 @@ package xray
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/docker-slim/docker-slim/pkg/app/master/commands"
@@ -420,6 +421,19 @@ func parseDetectUTF8(ctx *cli.Context) (*dockerimage.UTF8Detector, error) {
 		if len(outTarget) == 0 || outTarget == dockerimage.CDMDumpToConsole {
 			detector.DumpConsole = true
 		} else {
+			if strings.Contains(outTarget, ":") {
+				parts = strings.SplitN(outTarget, ":", 2)
+				if len(parts) != 2 {
+					return nil, fmt.Errorf("malformed find utf8: %s", raw)
+				}
+				outTarget = parts[0]
+				maxSizeBytes := parts[1]
+				var err error
+				detector.MaxSizeBytes, err = strconv.Atoi(maxSizeBytes)
+				if err != nil {
+					return nil, err
+				}
+			}
 			if strings.HasSuffix(outTarget, ".tgz") ||
 				strings.HasSuffix(outTarget, ".tar.gz") {
 				detector.DumpArchive = outTarget

--- a/pkg/docker/dockerimage/dockerimage.go
+++ b/pkg/docker/dockerimage/dockerimage.go
@@ -1135,10 +1135,9 @@ func inspectFile(
 				if utf8Detector.Dump {
 					if utf8Detector.Archive != nil {
 						if utf8Detector.MaxSizeBytes != 0 && object.Size > int64(utf8Detector.MaxSizeBytes) {
-							data = []byte(fmt.Sprintf("hash: %s size: %d [content omitted because too large]", hash, object.Size))
 							fileInfo := &utf8FileInfo{
 								name:    hash,
-								size:    int64(len(data)),
+								size:    int64(utf8Detector.MaxSizeBytes),
 								modtime: object.ModTime,
 							}
 							header, err := tar.FileInfoHeader(fileInfo, hash)
@@ -1150,7 +1149,7 @@ func inspectFile(
 							if err != nil {
 								return err
 							}
-							_, err = utf8Detector.Archive.Writer.Write(data)
+							_, err = utf8Detector.Archive.Writer.Write(data[:utf8Detector.MaxSizeBytes])
 							if err != nil {
 								return err
 							}


### PR DESCRIPTION
This PR extends the `--dectect-utf8` flag to optionally pass a MaxSizeBytes parameter to exclude large content from the produced tarball.