### PR TITLE
docker-slim run should kill container on sigint

### DIFF
--- a/pkg/app/master/container/execution.go
+++ b/pkg/app/master/container/execution.go
@@ -465,10 +465,10 @@ func (ref *Execution) monitorSysExit() {
 	go func() {
 		<-signals
 		ref.isInterrupted = true
-		//_ = ref.APIClient.KillContainer(dockerapi.KillContainerOptions{ID: ref.ContainerID})
-		//if ref.logger != nil {
-		//	ref.logger.Debugf("Execution.monitorSysExit: received SIGINT, killing container %s", ref.ContainerID)
-		//}
+		_ = ref.APIClient.KillContainer(dockerapi.KillContainerOptions{ID: ref.ContainerID})
+		if ref.logger != nil {
+			ref.logger.Debugf("Execution.monitorSysExit: received SIGINT, killing container %s", ref.ContainerID)
+		}
 
 		if ref.eventCh != nil {
 			ref.eventCh <- &ExecutionEvenInfo{


### PR DESCRIPTION
when i sigint `docker-slim run`, it leaves the container it started running. i want it to stop.