### PR TITLE
Set link in script install to raw file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ If the directory where you extracted the binaries is not in your PATH then you'l
 You can also use this script to install the current release of DockerSlim on Linux (x86 and ARM) and macOS (x86 and Apple Silicon)
 
 ```bash
-curl -sL https://github.com/docker-slim/docker-slim/blob/master/scripts/install_dockerslim.sh | sudo -E bash -
+curl -sL https://raw.githubusercontent.com/docker-slim/docker-slim/master/scripts/install-dockerslim.sh | sudo -E bash -
 ```
 
 ### Homebrew


### PR DESCRIPTION
What
===============
Set the url used in the scripted install to the raw file, not the html page

Why
===============
The url for the install script in the README should point to the "raw" file at https://raw.githubusercontent.com/docker-slim/docker-slim/master/scripts/install-dockerslim.sh

At the moment, the linked url is to the non raw file, so curl downloads an html page instead, and returns an error when trying to run it as a script.

How Tested
===============
 1. Copy the curl command from the README (`curl -sL https://github.com/docker-slim/docker-slim/blob/master/scripts/install_dockerslim.sh | sudo -E bash -`)
  The terminal will respond with the following error:
```
bash: line 7: syntax error near unexpected token `newline'
bash: line 7: `<!DOCTYPE html>'
```

