### PR TITLE
ISSUE #226: populate service network alias

### DIFF
--- a/pkg/app/master/commands/build/handler.go
+++ b/pkg/app/master/commands/build/handler.go
@@ -286,7 +286,7 @@ func OnCommand(
 		targetRef = fatImageRepoNameTag
 		//todo: remove the temporary fat image (should have a flag for it in case users want the fat image too)
 	}
-
+	serviceAliases := []string{}
 	var depServicesExe *compose.Execution
 	if composeFile != "" {
 		if targetComposeSvc != "" && depIncludeComposeSvcDeps != targetComposeSvc {
@@ -302,6 +302,11 @@ func OnCommand(
 				depExcludeComposeSvcs = append(depExcludeComposeSvcs, targetComposeSvc)
 			}
 		}
+
+		// when more than one target is supported
+		// this should be done per service name
+		serviceAliases = depExcludeComposeSvcs
+		logger.Debugf("compose: serviceAliases='%s'\n", serviceAliases)
 
 		selectors := compose.NewServiceSelectors(depIncludeComposeSvcDeps,
 			depIncludeComposeSvcs,
@@ -634,6 +639,7 @@ func OnCommand(
 		doIncludeCertPKAll,
 		doIncludeCertPKDirs,
 		selectedNetNames,
+		serviceAliases,
 		gparams.Debug,
 		gparams.InContainer,
 		true,

--- a/pkg/app/master/commands/profile/handler.go
+++ b/pkg/app/master/commands/profile/handler.go
@@ -22,7 +22,7 @@ import (
 	v "github.com/docker-slim/docker-slim/pkg/version"
 
 	"github.com/dustin/go-humanize"
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -249,6 +249,7 @@ func OnCommand(
 		false, //doIncludeCertPKAll
 		false, //doIncludeCertPKDirs
 		nil,   //selectedNetNames
+		nil,
 		gparams.Debug,
 		gparams.InContainer,
 		true,


### PR DESCRIPTION
[Fixes-226](https://github.com/docker-slim/docker-slim/issues/226)
==================================================================

What
===============
* Add service alias for docker-compose support

Why
===============
* To allow the use of alias addresses from within the container


How Tested
===============
* `docker inspect` to confirm alias
* `docker exec` to container, install ping, ping service names
 
 Test Output
 ===============
 
 **Docker Inspect**
```bash
❯ docker ps
CONTAINER ID   IMAGE                  COMMAND                  CREATED       STATUS       PORTS                                                                  NAMES
70d047fdec10   bitnami/ghost:4        "/opt/dockerslim/bin…"   2 hours ago   Up 2 hours   3000/tcp, 0.0.0.0:65501-65502->65501-65502/tcp, 0.0.0.0:80->2368/tcp   dockerslimk_872202_20211001205746
b4f31beeb84e   bitnami/mariadb:10.3   "/opt/bitnami/script…"   2 hours ago   Up 2 hours   3306/tcp                                                               dsbuild_872202_20211001205742_mariadb
```

```bash
❯ docker inspect 70d047fdec10
[
    {
        "Id": "70d047fdec10b671348b45ef564a606108e6223440b3c04ae9356d81e69995b1",
        "Created": "2021-10-01T20:57:46.47948432Z",
        "Path": "/opt/dockerslim/bin/docker-slim-sensor",
        "Args": [],
        "State": {
            "Status": "running",
            "Running": true,
            "Paused": false,
            "Restarting": false,
            "OOMKilled": false,
            "Dead": false,
            "Pid": 872629,
            "ExitCode": 0,
            "Error": "",
            "StartedAt": "2021-10-01T20:57:46.965853465Z",
            "FinishedAt": "0001-01-01T00:00:00Z"
        },
        "Image": "sha256:321363dd525f4d630d5686d758767eb29b8feb14c1291e24f975cae31f9b1826",
        "ResolvConfPath": "/var/lib/docker/containers/70d047fdec10b671348b45ef564a606108e6223440b3c04ae9356d81e69995b1/resolv.conf",
        "HostnamePath": "/var/lib/docker/containers/70d047fdec10b671348b45ef564a606108e6223440b3c04ae9356d81e69995b1/hostname",
        "HostsPath": "/var/lib/docker/containers/70d047fdec10b671348b45ef564a606108e6223440b3c04ae9356d81e69995b1/hosts",
        "LogPath": "/var/lib/docker/containers/70d047fdec10b671348b45ef564a606108e6223440b3c04ae9356d81e69995b1/70d047fdec10b671348b45ef564a606108e6223440b3c04ae9356d81e69995b1-json.log",
        "Name": "/dockerslimk_872202_20211001205746",
        "RestartCount": 0,
        "Driver": "overlay2",
        "Platform": "linux",
        "MountLabel": "",
        "ProcessLabel": "",
        "AppArmorProfile": "unconfined",
        "ExecIDs": null,
        "HostConfig": {
            "Binds": [
                "docker-slim-sensor.1.37.0-2-g59fe427:/opt/dockerslim/bin:ro"
            ],
            "ContainerIDFile": "",
            "LogConfig": {
                "Type": "json-file",
                "Config": {}
            },
            "NetworkMode": "default",
            "PortBindings": {
                "2368/tcp": [
                    {
                        "HostIp": "",
                        "HostPort": "80"
                    }
                ],
                "65501/tcp": [
                    {
                        "HostIp": "",
                        "HostPort": "65501"
                    }
                ],
                "65502/tcp": [
                    {
                        "HostIp": "",
                        "HostPort": "65502"
                    }
                ]
            },
            "RestartPolicy": {
                "Name": "",
                "MaximumRetryCount": 0
            },
            "AutoRemove": false,
            "VolumeDriver": "",
            "VolumesFrom": null,
            "CapAdd": [
                "SYS_ADMIN"
            ],
            "CapDrop": null,
            "CgroupnsMode": "host",
            "Dns": null,
            "DnsOptions": null,
            "DnsSearch": null,
            "ExtraHosts": null,
            "GroupAdd": null,
            "IpcMode": "private",
            "Cgroup": "",
            "Links": null,
            "OomScoreAdj": 0,
            "PidMode": "",
            "Privileged": true,
            "PublishAllPorts": false,
            "ReadonlyRootfs": false,
            "SecurityOpt": [
                "label=disable"
            ],
            "UTSMode": "",
            "UsernsMode": "host",
            "ShmSize": 67108864,
            "Runtime": "runc",
            "ConsoleSize": [
                0,
                0
            ],
            "Isolation": "",
            "CpuShares": 0,
            "Memory": 0,
            "NanoCpus": 0,
            "CgroupParent": "",
            "BlkioWeight": 0,
            "BlkioWeightDevice": null,
            "BlkioDeviceReadBps": null,
            "BlkioDeviceWriteBps": null,
            "BlkioDeviceReadIOps": null,
            "BlkioDeviceWriteIOps": null,
            "CpuPeriod": 0,
            "CpuQuota": 0,
            "CpuRealtimePeriod": 0,
            "CpuRealtimeRuntime": 0,
            "CpusetCpus": "",
            "CpusetMems": "",
            "Devices": null,
            "DeviceCgroupRules": null,
            "DeviceRequests": null,
            "KernelMemory": 0,
            "KernelMemoryTCP": 0,
            "MemoryReservation": 0,
            "MemorySwap": 0,
            "MemorySwappiness": null,
            "OomKillDisable": false,
            "PidsLimit": null,
            "Ulimits": null,
            "CpuCount": 0,
            "CpuPercent": 0,
            "IOMaximumIOps": 0,
            "IOMaximumBandwidth": 0,
            "MaskedPaths": null,
            "ReadonlyPaths": null
        },
        "GraphDriver": {
            "Data": {
                "LowerDir": "/var/lib/docker/overlay2/6ba2a8c52b4d7827530cffd23ebd9cd18524b083754fb8e9006e24d66539b348-init/diff:/var/lib/docker/overlay2/a1ec1f2da4dfb1e551a48e287561a15ab3126ac200628ede80ff3ddb86fb43f6/diff:/var/lib/docker/overlay2/9ffa33e64c573de08df07265829a447a6c843e8bacdff97c39c20a32935b1ae2/diff:/var/lib/docker/overlay2/2ad4ab221da3469af6184f54befded848eb6b22878558008b8c1495fb5299fb3/diff:/var/lib/docker/overlay2/6f61308488a9b01ce2d798481b9a576d2f2a7c634b7a4df4d463882a6dc44313/diff:/var/lib/docker/overlay2/a7af8cf351f8c5dcb7e91c3d6df625796f008944f356439fe97d0c67d7b97955/diff:/var/lib/docker/overlay2/96ddb519a200981804b4954008cb68cec0d43a03ae7784f9bf961954d5be32c9/diff:/var/lib/docker/overlay2/561e118d1fcdb727788a4800048da3cc5e1618d0eb33d8c12ac97a689c56c4d1/diff:/var/lib/docker/overlay2/61069ce351686bc6505ef4f6273af5d98646f18ffe0375f617076c7657c23156/diff:/var/lib/docker/overlay2/46894dd7e344b21b1069097718887afaccf4a315d03d9604f04e0e2a45f81f0c/diff:/var/lib/docker/overlay2/af477d728268e5ec3365678763c3060216087ef9355c7dc5624f9aa0336c6d78/diff:/var/lib/docker/overlay2/857b5d7c957b308cfe828cbe3a535a5408f79ef4a23e8e04ad581b2559e6745e/diff:/var/lib/docker/overlay2/c584da50729bb692d25da20e7463dc5b5627dc79663fb17196cc4c39162576e3/diff",
                "MergedDir": "/var/lib/docker/overlay2/6ba2a8c52b4d7827530cffd23ebd9cd18524b083754fb8e9006e24d66539b348/merged",
                "UpperDir": "/var/lib/docker/overlay2/6ba2a8c52b4d7827530cffd23ebd9cd18524b083754fb8e9006e24d66539b348/diff",
                "WorkDir": "/var/lib/docker/overlay2/6ba2a8c52b4d7827530cffd23ebd9cd18524b083754fb8e9006e24d66539b348/work"
            },
            "Name": "overlay2"
        },
        "Mounts": [
            {
                "Type": "volume",
                "Name": "docker-slim-sensor.1.37.0-2-g59fe427",
                "Source": "/var/lib/docker/volumes/docker-slim-sensor.1.37.0-2-g59fe427/_data",
                "Destination": "/opt/dockerslim/bin",
                "Driver": "local",
                "Mode": "ro",
                "RW": false,
                "Propagation": ""
            },
            {
                "Type": "volume",
                "Name": "64081f805bb44f3413daa08f6e198ad6315914c96af995128d124b56dac601fc",
                "Source": "/var/lib/docker/volumes/64081f805bb44f3413daa08f6e198ad6315914c96af995128d124b56dac601fc/_data",
                "Destination": "/opt/dockerslim/artifacts",
                "Driver": "local",
                "Mode": "",
                "RW": true,
                "Propagation": ""
            }
        ],
        "Config": {
            "Hostname": "70d047fdec10",
            "Domainname": "",
            "User": "0:0",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "ExposedPorts": {
                "2368/tcp": {},
                "3000/tcp": {},
                "65501/tcp": {},
                "65502/tcp": {}
            },
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": [
                "ALLOW_EMPTY_PASSWORD=yes",
                "GHOST_DATABASE_HOST=mariadb",
                "GHOST_DATABASE_PORT_NUMBER=3306",
                "GHOST_DATABASE_USER=bn_ghost",
                "GHOST_DATABASE_NAME=bitnami_ghost",
                "GHOST_DATABASE_HOST=mariadb",
                "PATH=/opt/bitnami/python/bin:/opt/bitnami/node/bin:/opt/bitnami/mysql/bin:/opt/bitnami/common/bin:/opt/bitnami/ghost/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                "HOME=/",
                "OS_ARCH=amd64",
                "OS_FLAVOUR=debian-10",
                "OS_NAME=linux",
                "BITNAMI_APP_NAME=ghost",
                "BITNAMI_IMAGE_VERSION=4.15.1-debian-10-r1",
                "LD_PRELOAD=/opt/bitnami/common/lib/libnss_wrapper.so",
                "LNAME=ghost",
                "MARIADB_HOST=mariadb",
                "MARIADB_PORT_NUMBER=3306",
                "MARIADB_ROOT_PASSWORD=",
                "MARIADB_ROOT_USER=root",
                "MYSQL_CLIENT_CREATE_DATABASE_NAME=",
                "MYSQL_CLIENT_CREATE_DATABASE_PASSWORD=",
                "MYSQL_CLIENT_CREATE_DATABASE_PRIVILEGES=ALL",
                "MYSQL_CLIENT_CREATE_DATABASE_USER=",
                "MYSQL_CLIENT_ENABLE_SSL=no",
                "MYSQL_CLIENT_SSL_CA_FILE=",
                "NSS_WRAPPER_GROUP=/opt/bitnami/ghost/nss-wrapper/nss_group",
                "NSS_WRAPPER_PASSWD=/opt/bitnami/ghost/nss-wrapper/nss_passwd"
            ],
            "Cmd": null,
            "Image": "docker.io/bitnami/ghost:4",
            "Volumes": {
                "/opt/dockerslim/artifacts": {}
            },
            "WorkingDir": "/opt/bitnami/ghost",
            "Entrypoint": [
                "/opt/dockerslim/bin/docker-slim-sensor"
            ],
            "OnBuild": null,
            "Labels": {
                "maintainer": "Bitnami <containers@bitnami.com>",
                "runtime.container.type": "dockerslim"
            }
        },
        "NetworkSettings": {
            "Bridge": "",
            "SandboxID": "d8f050827e409b4ad2f6ffbb18e891e26731279ff9901951f1876024bd191d86",
            "HairpinMode": false,
            "LinkLocalIPv6Address": "",
            "LinkLocalIPv6PrefixLen": 0,
            "Ports": {
                "2368/tcp": [
                    {
                        "HostIp": "0.0.0.0",
                        "HostPort": "80"
                    }
                ],
                "3000/tcp": null,
                "65501/tcp": [
                    {
                        "HostIp": "0.0.0.0",
                        "HostPort": "65501"
                    }
                ],
                "65502/tcp": [
                    {
                        "HostIp": "0.0.0.0",
                        "HostPort": "65502"
                    }
                ]
            },
            "SandboxKey": "/var/run/docker/netns/d8f050827e40",
            "SecondaryIPAddresses": null,
            "SecondaryIPv6Addresses": null,
            "EndpointID": "025ea67e34f83f0a8ad037ad4b42458ed2f44b20543dd2641ec80a2e31179f11",
            "Gateway": "172.17.0.1",
            "GlobalIPv6Address": "",
            "GlobalIPv6PrefixLen": 0,
            "IPAddress": "172.17.0.2",
            "IPPrefixLen": 16,
            "IPv6Gateway": "",
            "MacAddress": "02:42:ac:11:00:02",
            "Networks": {
                "bridge": {
                    "IPAMConfig": null,
                    "Links": null,
                    "Aliases": null,
                    "NetworkID": "4bd2abe770ed7c7aba873af74fed1df35c82004651b08b7684c6bc7f6af2160a",
                    "EndpointID": "025ea67e34f83f0a8ad037ad4b42458ed2f44b20543dd2641ec80a2e31179f11",
                    "Gateway": "172.17.0.1",
                    "IPAddress": "172.17.0.2",
                    "IPPrefixLen": 16,
                    "IPv6Gateway": "",
                    "GlobalIPv6Address": "",
                    "GlobalIPv6PrefixLen": 0,
                    "MacAddress": "02:42:ac:11:00:02",
                    "DriverOpts": null
                },
                "dsbuild_872202_20211001205742_default": {
                    "IPAMConfig": null,
                    "Links": null,
                    "Aliases": [
                        "ghost",
                        "70d047fdec10"
                    ],
                    "NetworkID": "3dd5dddf09e1cee12d3175b10f5678626bf732ea3fc49beeec459136e5afbb6c",
                    "EndpointID": "d390664488000e7aa033ee9ce392636c064a42c837584496b1cc0bae63d33207",
                    "Gateway": "172.20.0.1",
                    "IPAddress": "172.20.0.3",
                    "IPPrefixLen": 16,
                    "IPv6Gateway": "",
                    "GlobalIPv6Address": "",
                    "GlobalIPv6PrefixLen": 0,
                    "MacAddress": "02:42:ac:14:00:03",
                    "DriverOpts": null
                }
            }
        }
    }
]
```

**Ping Output**
```bash
❯ docker exec -it 70d047fdec10 sh
# ping ghost -c1
PING ghost (172.20.0.3) 56(84) bytes of data.
64 bytes from 70d047fdec10 (172.20.0.3): icmp_seq=1 ttl=64 time=0.023 ms

--- ghost ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.023/0.023/0.023/0.000 ms
# ping mariadb -c1
PING mariadb (172.20.0.2) 56(84) bytes of data.
64 bytes from dsbuild_872202_20211001205742_mariadb.dsbuild_872202_20211001205742_default (172.20.0.2): icmp_seq=1 ttl=64 time=0.064 ms

--- mariadb ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.064/0.064/0.064/0.000 ms

```