### PR TITLE
Gitpod button opens gitpod env

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,7 +879,7 @@ Use Go 1.13 or higher. You can use earlier version of Go, but it can't be lower 
 
 If you have a web browser, you can get a fully pre-configured development environment in one click:
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://gitpod.io/#https://github.com/docker-slim/docker-slim)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/docker-slim/docker-slim)
 
 
 ##### Additional Tools


### PR DESCRIPTION
[Fixes-242](https://github.com/docker-slim/docker-slim/issues/242)
==================================================================

What
===============
- Bottom Open in Gitpod button leads the user to a `Something went wrong` page.


Why
===============
- Consistent behavior of the Gitpod entrypoints from the top level README


How Tested
===============
- Click on the Open in Gitpod button
- You should land in the prepared environment

