### PR TITLE
Conditionally concatenate base image cmd to user provided entrypoint

### DIFF
--- a/pkg/app/master/inspectors/container/container_inspector.go
+++ b/pkg/app/master/inspectors/container/container_inspector.go
@@ -254,7 +254,11 @@ func NewInspector(
 		}
 
 	} else if len(imageInspector.ImageInfo.Config.Cmd) > 0 {
-		inspector.FatContainerCmd = append(inspector.FatContainerCmd, imageInspector.ImageInfo.Config.Cmd...)
+		for _, cmd := range imageInspector.ImageInfo.Config.Cmd {
+			if cmd != "sh" {
+				inspector.FatContainerCmd = append(inspector.FatContainerCmd, imageInspector.ImageInfo.Config.Cmd...)
+			}
+		}
 	}
 
 	emptyIdx := -1

--- a/pkg/app/master/inspectors/container/container_inspector.go
+++ b/pkg/app/master/inspectors/container/container_inspector.go
@@ -278,7 +278,6 @@ func NewInspector(
 
 	if emptyIdx > -1 {
 		inspector.FatContainerCmd = inspector.FatContainerCmd[emptyIdx+1:]
-		fmt.Println("wot is fat container cmd - point D", inspector.FatContainerCmd)
 	}
 
 	logger.Debugf("FatContainerCmd - %+v", inspector.FatContainerCmd)
@@ -286,13 +285,10 @@ func NewInspector(
 	inspector.dockerEventCh = make(chan *dockerapi.APIEvents)
 	inspector.dockerEventStopCh = make(chan struct{})
 
-	fmt.Println("wot is fat container cmd - point E", inspector.FatContainerCmd)
-
 	return inspector, nil
 }
 
 // RunContainer starts the container inspector instance execution
-// ends at line 970.
 func (i *Inspector) RunContainer() error {
 	artifactsPath := filepath.Join(i.LocalVolumePath, ArtifactsDir)
 	sensorPath := filepath.Join(fsutil.ExeDir(), SensorBinLocal)
@@ -859,18 +855,6 @@ func (i *Inspector) RunContainer() error {
 		cmd.AppArgs = i.FatContainerCmd[1:]
 	}
 
-	fmt.Println("checking out the command AppName: ", cmd.AppName)
-	fmt.Println("checking out the command len(AppName): ", len(cmd.AppName))
-	fmt.Println("checking out the commands AppArgs: ", cmd.AppArgs)
-	// fmt.Println("checking out the commands len(AppArgs): ", len(cmd.AppArgs))
-	// fmt.Println("first app arg", cmd.AppArgs[0])
-	// fmt.Println("first app arg length", len(cmd.AppArgs[0])) // we expect the length to be 2
-	// cnd,AppArgs is an array of strings
-	// the len is only 1; and that entry appears to be the string 'sh'
-
-	// checking out the command AppName:  whoami
-	// checking out the commands AppArgs:  [sh]
-
 	if len(i.ExcludePatterns) > 0 {
 		cmd.Excludes = pathMapKeys(i.ExcludePatterns)
 	}
@@ -912,8 +896,6 @@ func (i *Inspector) RunContainer() error {
 		}
 	}
 
-	// question - curious what the cmd looks like here?
-	fmt.Println("das cmd", cmd)
 	_, err = i.ipcClient.SendCommand(cmd)
 	if err != nil {
 		return err

--- a/pkg/app/master/inspectors/container/container_inspector.go
+++ b/pkg/app/master/inspectors/container/container_inspector.go
@@ -235,19 +235,15 @@ func NewInspector(
 		crOpts:      crOpts,
 	}
 
-	fmt.Println("wot is initial fat container cmd?", inspector.FatContainerCmd)
-
 	if overrides != nil && ((len(overrides.Entrypoint) > 0) || overrides.ClearEntrypoint) {
 		logger.Debugf("overriding Entrypoint %+v => %+v (%v)",
 			imageInspector.ImageInfo.Config.Entrypoint, overrides.Entrypoint, overrides.ClearEntrypoint)
 		if len(overrides.Entrypoint) > 0 {
 			inspector.FatContainerCmd = append(inspector.FatContainerCmd, overrides.Entrypoint...)
-			fmt.Println("wot is fat container cmd - point A.1", inspector.FatContainerCmd)
 		}
 
 	} else if len(imageInspector.ImageInfo.Config.Entrypoint) > 0 {
 		inspector.FatContainerCmd = append(inspector.FatContainerCmd, imageInspector.ImageInfo.Config.Entrypoint...)
-		fmt.Println("wot is fat container cmd - point A.2", inspector.FatContainerCmd)
 	}
 
 	if overrides != nil && ((len(overrides.Cmd) > 0) || overrides.ClearCmd) {
@@ -255,7 +251,6 @@ func NewInspector(
 			imageInspector.ImageInfo.Config.Cmd, overrides.Cmd, overrides.ClearCmd)
 		if len(overrides.Cmd) > 0 {
 			inspector.FatContainerCmd = append(inspector.FatContainerCmd, overrides.Cmd...)
-			fmt.Println("wot is fat container cmd - point B", inspector.FatContainerCmd)
 		}
 
 	} else if len(imageInspector.ImageInfo.Config.Cmd) > 0 {

--- a/pkg/app/master/inspectors/container/container_inspector.go
+++ b/pkg/app/master/inspectors/container/container_inspector.go
@@ -254,9 +254,9 @@ func NewInspector(
 		}
 
 	} else if len(imageInspector.ImageInfo.Config.Cmd) > 0 {
-		for _, cmd := range imageInspector.ImageInfo.Config.Cmd {
+		for index, cmd := range imageInspector.ImageInfo.Config.Cmd {
 			if cmd != "sh" {
-				inspector.FatContainerCmd = append(inspector.FatContainerCmd, imageInspector.ImageInfo.Config.Cmd...)
+				inspector.FatContainerCmd = append(inspector.FatContainerCmd, imageInspector.ImageInfo.Config.Cmd[index])
 			}
 		}
 	}


### PR DESCRIPTION
[Fixes-206](https://github.com/docker-slim/docker-slim/issues/206)
==================================================================

What
===============
- Check if base image cmd is equal to `"sh"` prior to appending base image cmd to user provided entrypoint. 


Why
===============
- Prior to this patch, a base image (such as amd64/ubuntu) with a `ImageInfo.Config.Cmd[index]` == `"sh"` would concatenate the provided entrypoint (e.g. `whoami`) with `sh`. As a result, the container would run `whoami sh` - which led to the following behavior 
![image](https://user-images.githubusercontent.com/24369866/141182254-fe54add1-aee7-4ed0-837c-ac382e8dd73c.png)



How Tested
===============
- Run `docker-slim build --target docker pull amd64/ubuntu --tag ubuntu:slim --pull --http-probe=false --entrypoint='whoami'`
- If you tail the logs of the container that runs as a result of the above command, then you should see output comparable to the following screenshot: 
![image](https://user-images.githubusercontent.com/24369866/141181727-4540dbb9-36b0-4bde-9465-640fc07c9d30.png)
- Note the output of `root` as opposed to the previous output reported in [Issue 206](https://github.com/docker-slim/docker-slim/issues/206)

