### PR TITLE
fix: graceful handle of panic: close of nil channel

### DIFF
--- a/pkg/app/master/inspectors/container/container_inspector.go
+++ b/pkg/app/master/inspectors/container/container_inspector.go
@@ -1077,6 +1077,9 @@ func (i *Inspector) ShutdownContainer() error {
 
 // FinishMonitoring ends the target container monitoring activities
 func (i *Inspector) FinishMonitoring() {
+	if i.dockerEventStopCh == nil {
+		errutil.FailOn(fmt.Errorf("docker event stop chanel is nil"))
+	}
 	close(i.dockerEventStopCh)
 	i.dockerEventStopCh = nil
 


### PR DESCRIPTION
Signed-off-by: Engin Diri <engin.diri@mail.schwarz>

[Fixes-246](https://github.com/docker-slim/docker-slim/issues/246)
==================================================================

What
===============
Added graceful handle of panic: close of nil channel

Why
===============
docker-slim is not crashing anymore

How Tested
===============


