### PR TITLE
add a new container probe for multi container builds with docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ In the interactive CLI prompt mode you must specify the target image using the `
 - `compose-env-file` - Load compose env vars from file (host env vars override the values loaded from this file)
 - `compose-workdir` - Set custom work directory for compose
 - `compose-project-name` - Use custom project name for compose
+- `container-probe-compose-svc` - Set container probe to compose service
 - `prestart-compose-svc` - placeholder for now
 - `poststart-compose-svc` - placeholder for now
 - `--http-probe` - Enables/disables HTTP probing (ENABLED by default; you have to disable the probe if you don't need it by setting the flag to `false`: `--http-probe=false`)

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ In the interactive CLI prompt mode you must specify the target image using the `
 - `--container-dns` - Add a dns server analyzing image at runtime [can use this flag multiple times]
 - `--container-dns-search` - Add a dns search domain for unqualified hostnames analyzing image at runtime [can use this flag multiple times]
 - `--image-overrides` - Save runtime overrides in generated image (values is `all` or a comma delimited list of override types: `entrypoint`, `cmd`, `workdir`, `env`, `expose`, `volume`, `label`). Use this flag if you need to set a runtime value and you want to persist it in the optimized image. If you only want to add, edit or delete an image value in the optimized image use one of the `--new-*` or `--remove-*` flags (define below).
-- `--continue-after` - Select continue mode: `enter` | `signal` | `probe` | `exec` | `timeout` or numberInSeconds (default value if http probes are disabled: `enter`). You can also select `probe` and `exec` together: `'probe&exec'` (make sure to use quotes around the two modes or the `&` will break the shell command).
+- `--continue-after` - Select continue mode: `enter` | `signal` | `probe` | `exec` | `timeout-number-in-seconds` | `container.probe` (default value if http probes are disabled: `enter`). You can also select `probe` and `exec` together: `'probe&exec'` (make sure to use quotes around the two modes or the `&` will break the shell command).
 - `--dockerfile` - The source Dockerfile name to build the fat image before it's optimized.
 - `--tag-fat` - Custom tag for the fat image built from Dockerfile.
 - `--cbo-add-host` - Add an extra host-to-IP mapping in /etc/hosts to use when building an image (Container Build Option).
@@ -957,4 +957,3 @@ Apache License v2, see [LICENSE](https://github.com/docker-slim/docker-slim/blob
 ---
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/docker-slim/docker-slim)](https://goreportcard.com/report/github.com/docker-slim/docker-slim)
-

--- a/pkg/app/master/commands/build/cli.go
+++ b/pkg/app/master/commands/build/cli.go
@@ -44,6 +44,7 @@ var CLI = cli.Command{
 		commands.Cflag(commands.FlagComposeEnvFile),
 		commands.Cflag(commands.FlagComposeProjectName),
 		commands.Cflag(commands.FlagComposeWorkdir),
+		commands.Cflag(commands.FlagContainerProbeComposeSvc),
 
 		commands.Cflag(commands.FlagHTTPProbeOff),
 		commands.Cflag(commands.FlagHTTPProbe),
@@ -220,6 +221,7 @@ var CLI = cli.Command{
 
 		composeProjectName := ctx.String(commands.FlagComposeProjectName)
 		composeWorkdir := ctx.String(commands.FlagComposeWorkdir)
+		containerProbeComposeSvc := ctx.String(commands.FlagContainerProbeComposeSvc)
 
 		var targetRef string
 
@@ -613,6 +615,19 @@ var CLI = cli.Command{
 			}
 		}
 
+		if containerProbeComposeSvc != "" {
+			continueAfter.Mode = config.CAMContainerProbe
+			xc.Out.Info("exec",
+				ovars{
+					"message": "changing continue-after to container-probe",
+				})
+			doHTTPProbe = false
+			xc.Out.Info("exec",
+				ovars{
+					"message": "changing http-probe to false",
+				})
+		}
+
 		if continueAfter.Mode == "" {
 			continueAfter.Mode = config.CAMEnter
 			xc.Out.Info("exec",
@@ -648,6 +663,7 @@ var CLI = cli.Command{
 			composeEnvNoHost,
 			composeWorkdir,
 			composeProjectName,
+			containerProbeComposeSvc,
 			cbOpts,
 			crOpts,
 			outputTags,

--- a/pkg/app/master/commands/build/prompt.go
+++ b/pkg/app/master/commands/build/prompt.go
@@ -25,6 +25,7 @@ var CommandFlagSuggestions = &commands.FlagSuggestions{
 		{Text: commands.FullFlagName(commands.FlagComposeEnvFile), Description: commands.FlagComposeEnvFileUsage},
 		{Text: commands.FullFlagName(commands.FlagComposeProjectName), Description: commands.FlagComposeProjectNameUsage},
 		{Text: commands.FullFlagName(commands.FlagComposeWorkdir), Description: commands.FlagComposeWorkdirUsage},
+		{Text: commands.FullFlagName(commands.FlagContainerProbeComposeSvc), Description: commands.FlagContainerProbeComposeSvcUsage},
 		{Text: commands.FullFlagName(commands.FlagPull), Description: commands.FlagPullUsage},
 		{Text: commands.FullFlagName(commands.FlagShowPullLogs), Description: commands.FlagShowPullLogsUsage},
 		{Text: commands.FullFlagName(commands.FlagRegistryAccount), Description: commands.FlagRegistryAccountUsage},

--- a/pkg/app/master/commands/cliflags.go
+++ b/pkg/app/master/commands/cliflags.go
@@ -73,6 +73,7 @@ const (
 	FlagPrestartComposeSvc             = "prestart-compose-svc"
 	FlagPoststartComposeSvc            = "poststart-compose-svc"
 	FlagPrestartComposeWaitExit        = "prestart-compose-wait-exit"
+	FlagContainerProbeComposeSvc       = "container-probe-compose-svc"
 
 	FlagRemoveFileArtifacts = "remove-file-artifacts"
 	FlagCopyMetaArtifacts   = "copy-meta-artifacts"
@@ -158,6 +159,7 @@ const (
 	FlagComposeEnvNoHostUsage               = "Don't include the env vars from the host to compose"
 	FlagComposeEnvFileUsage                 = "Load compose env vars from file (host env vars override the values loaded from this file)"
 	FlagComposeWorkdirUsage                 = "Set custom work directory for compose"
+	FlagContainerProbeComposeSvcUsage       = "Set container probe to compose service"
 	FlagComposeProjectNameUsage             = "Use custom project name for compose"
 	FlagPrestartComposeSvcUsage             = "Run selected compose service(s) before any other compose services or target container"
 	FlagPoststartComposeSvcUsage            = "Run selected compose service(s) after the target container is running (need a new continue after mode too)"
@@ -404,6 +406,12 @@ var CommonFlags = map[string]cli.Flag{
 		Value:  "",
 		Usage:  FlagComposeWorkdirUsage,
 		EnvVar: "DSLIM_COMPOSE_WORKDIR",
+	},
+	FlagContainerProbeComposeSvc: cli.StringFlag{
+		Name:   FlagContainerProbeComposeSvc,
+		Value:  "",
+		Usage:  FlagContainerProbeComposeSvcUsage,
+		EnvVar: "DSLIM_CONTAINER_PROBE_COMPOSE_SVC",
 	},
 	FlagPrestartComposeSvc: cli.StringSliceFlag{
 		Name:   FlagPrestartComposeSvc,

--- a/pkg/app/master/commands/cliflags.go
+++ b/pkg/app/master/commands/cliflags.go
@@ -197,7 +197,7 @@ const (
 	FlagExcludePatternUsage  = "Exclude path pattern (Glob/Match in Go and **) from image"
 	FlagUseLocalMountsUsage  = "Mount local paths for target container artifact input and output"
 	FlagUseSensorVolumeUsage = "Sensor volume name to use"
-	FlagContinueAfterUsage   = "Select continue mode: enter | signal | probe | timeout or numberInSeconds"
+	FlagContinueAfterUsage   = "Select continue mode: enter | signal | probe | timeout-number-in-seconds | container.probe"
 
 	FlagExecUsage     = "A shell script snippet to run via Docker exec"
 	FlagExecFileUsage = "A shell script file to run via Docker exec"

--- a/pkg/app/master/commands/cliprompt.go
+++ b/pkg/app/master/commands/cliprompt.go
@@ -240,6 +240,7 @@ var continueAfterValues = []prompt.Suggest{
 	{Text: config.CAMEnter, Description: "Use the <enter> key to indicate you that you are done using the container"},
 	{Text: config.CAMSignal, Description: "Use SIGUSR1 to signal that you are done using the container"},
 	{Text: config.CAMTimeout, Description: "Automatically continue after the default timeout (60 seconds)"},
+	{Text: config.CAMContainerProbe, Description: "Automatically continue after the probed container exits"},
 	{Text: "<seconds>", Description: "Enter the number of seconds to wait instead of <seconds>"},
 }
 

--- a/pkg/app/master/config/config.go
+++ b/pkg/app/master/config/config.go
@@ -131,11 +131,12 @@ type DockerClient struct {
 }
 
 const (
-	CAMProbe   = "probe"
-	CAMEnter   = "enter"
-	CAMTimeout = "timeout"
-	CAMSignal  = "signal"
-	CAMExec    = "exec"
+	CAMContainerProbe = "container-probe"
+	CAMProbe          = "probe"
+	CAMEnter          = "enter"
+	CAMTimeout        = "timeout"
+	CAMSignal         = "signal"
+	CAMExec           = "exec"
 )
 
 // ContinueAfter provides the command execution mode parameters

--- a/pkg/app/sensor/artifacts.go
+++ b/pkg/app/sensor/artifacts.go
@@ -220,6 +220,7 @@ type artifactStore struct {
 	saFileMap     map[string]*report.ArtifactProps
 	cmd           *command.StartMonitor
 	appStacks     map[string]*appStackInfo
+	origPaths     map[string]interface{}
 }
 
 func newArtifactStore(storeLocation string,
@@ -241,6 +242,7 @@ func newArtifactStore(storeLocation string,
 		saFileMap:     map[string]*report.ArtifactProps{},
 		cmd:           cmd,
 		appStacks:     map[string]*appStackInfo{},
+		origPaths:     cmd.OrigPaths,
 	}
 
 	return store

--- a/pkg/app/sensor/monitors/fanotify/monitor.go
+++ b/pkg/app/sensor/monitors/fanotify/monitor.go
@@ -33,7 +33,7 @@ const (
 )
 
 // Run starts the FANOTIFY monitor
-func Run(errorCh chan error, mountPoint string, stopChan chan struct{}) <-chan *report.FanMonitorReport {
+func Run(errorCh chan error, mountPoint string, stopChan chan struct{}, origPaths map[string]interface{}) <-chan *report.FanMonitorReport {
 	log.Info("fanmon: Run")
 
 	nd, err := fanapi.Initialize(fanapi.FAN_CLASS_NOTIF, os.O_RDONLY)
@@ -132,6 +132,10 @@ func Run(errorCh chan error, mountPoint string, stopChan chan struct{}) <-chan *
 				fanReport.EventCount++
 				log.Debugf("fanmon: processor - [%v] handling event %v", fanReport.EventCount, e)
 
+				_, ok := origPaths[e.File]
+				if !ok {
+					continue done
+				}
 				if e.ID == 1 {
 					//first event represents the main process
 					if pinfo, err := getProcessInfo(e.Pid); (err == nil) && (pinfo != nil) {

--- a/pkg/app/sensor/monitors/ptrace/monitor.go
+++ b/pkg/app/sensor/monitors/ptrace/monitor.go
@@ -23,9 +23,9 @@ func Run(
 	appArgs []string,
 	dirName string,
 	appUser string,
-	runTargetAsUser bool) <-chan *report.PtMonitorReport {
+	runTargetAsUser bool,
+	origPaths map[string]interface{}) <-chan *report.PtMonitorReport {
 	log.Info("ptmon: Run")
-
 	ptApp, err := ptrace.Run(
 		appName,
 		appArgs,
@@ -35,7 +35,8 @@ func Run(
 		nil,
 		errorCh,
 		nil,
-		stopCh)
+		stopCh,
+		origPaths)
 	if err != nil {
 		if ackCh != nil {
 			ackCh <- false

--- a/pkg/app/sensor/monitors/ptrace/monitor_arm64.go
+++ b/pkg/app/sensor/monitors/ptrace/monitor_arm64.go
@@ -50,7 +50,8 @@ func Run(
 	appArgs []string,
 	dirName string,
 	appUser string,
-	runTargetAsUser bool) <-chan *report.PtMonitorReport {
+	runTargetAsUser bool,
+	origPaths map[string]interface{}) <-chan *report.PtMonitorReport {
 	log.Info("ptmon: Run")
 
 	sysInfo := system.GetSystemInfo()

--- a/pkg/ipc/command/command.go
+++ b/pkg/ipc/command/command.go
@@ -57,6 +57,7 @@ type StartMonitor struct {
 	IncludeCertDirs    bool                          `json:"include_cert_dirs,omitempty"`
 	IncludeCertPKAll   bool                          `json:"include_cert_pk_all,omitempty"`
 	IncludeCertPKDirs  bool                          `json:"include_cert_pk_dirs,omitempty"`
+	OrigPaths          map[string]interface{}        `json:"orig_paths"`
 }
 
 // GetName returns the command message ID for the start monitor command

--- a/pkg/monitor/ptrace/ptrace.go
+++ b/pkg/monitor/ptrace/ptrace.go
@@ -729,13 +729,14 @@ func getIntParam(pid int, ptr uint64) int {
 }
 
 func getStringParam(pid int, ptr uint64) string {
-	var out [4096]byte
+	var out [256]byte
 	var data []byte
 	for {
 		count, err := syscall.PtracePeekData(pid, uintptr(ptr), out[:])
 		if err != nil && err != syscall.EIO {
 			fmt.Printf("readString: syscall.PtracePeekData error - '%v'\v", err)
 		}
+
 		idx := bytes.IndexByte(out[:count], 0)
 		var foundNull bool
 		if idx == -1 {

--- a/pkg/system/system_linux_amd64.go
+++ b/pkg/system/system_linux_amd64.go
@@ -42,6 +42,15 @@ func CallSecondParam(regs syscall.PtraceRegs) uint64 {
 	return regs.Rsi
 }
 
+func CallThirdParam(regs syscall.PtraceRegs) uint64 {
+	return regs.Rdx
+}
+
+func CallFourthParam(regs syscall.PtraceRegs) uint64 {
+	return regs.Rcx
+}
+
+
 /*
 X86_32 SYSCALL REGISTER USE:
 


### PR DESCRIPTION
i have a compose file that looks like this:

```yml
version: "3.9"

services:

  database:
    build:
      dockerfile: extra/Dockerfile.database
    image: webapp:database${suffix:-}
    ports: ["27017"]

  backend:
    build:
      dockerfile: extra/Dockerfile.backend
    image: webapp:backend${suffix:-}
    ports: ["8080"]
    links: ["database"]

  frontend:
    build:
      dockerfile: extra/Dockerfile.frontend
    image: webapp:frontend${suffix:-}
    ports: ["8000"]

  test:
    build:
      dockerfile: extra/Dockerfile.test
    image: webapp:test
    links: ["frontend", "backend"]
```
i slim it using the following docker-slim invocations:

```bash

docker-slim build --compose-file docker-compose.yml --container-probe-compose-svc test --target-compose-svc database --tag webapp:database-slim
docker-slim build --compose-file docker-compose.yml --container-probe-compose-svc test --target-compose-svc backend  --tag webapp:backend-slim
docker-slim build --compose-file docker-compose.yml --container-probe-compose-svc test --target-compose-svc frontend --tag webapp:frontend-slim
```

then test the slimmed images with:

```bash
docker compose rm -f && suffix="-slim" docker compose up --exit-code-from test
```

initially my slimmed images didn't work, and i made the following improvements:
- ptrace should include file events from more syscalls
- ptrace should resolve relative filespaths using either the passed fd or the cwd
- the slimmed image should never include a file if it wasn't present in the original image