### PR TITLE
Propagate logging CLI flags to sensor

### DIFF
--- a/pkg/app/master/commands/build/cli.go
+++ b/pkg/app/master/commands/build/cli.go
@@ -668,7 +668,8 @@ var CLI = cli.Command{
 			execCmd,
 			string(execFileCmd),
 			deleteFatImage,
-			ctx.GlobalString(commands.FlagLogLevel))
+			ctx.GlobalString(commands.FlagLogLevel),
+			ctx.GlobalString(commands.FlagLogFormat))
 
 		return nil
 	},

--- a/pkg/app/master/commands/build/cli.go
+++ b/pkg/app/master/commands/build/cli.go
@@ -667,7 +667,8 @@ var CLI = cli.Command{
 			continueAfter,
 			execCmd,
 			string(execFileCmd),
-			deleteFatImage)
+			deleteFatImage,
+			ctx.GlobalString(commands.FlagLogLevel))
 
 		return nil
 	},

--- a/pkg/app/master/commands/build/handler.go
+++ b/pkg/app/master/commands/build/handler.go
@@ -126,7 +126,8 @@ func OnCommand(
 	execCmd string,
 	execFileCmd string,
 	deleteFatImage bool,
-	sensorLogLevel string) {
+	logLevel string,
+	logFormat string) {
 
 	const cmdName = Name
 	logger := log.WithFields(log.Fields{"app": appName, "command": cmdName})
@@ -873,7 +874,8 @@ func OnCommand(
 		doIncludeCertPKDirs,
 		selectedNetworks,
 		gparams.Debug,
-		sensorLogLevel,
+		logLevel,
+		logFormat,
 		gparams.InContainer,
 		true,
 		prefix)

--- a/pkg/app/master/commands/build/handler.go
+++ b/pkg/app/master/commands/build/handler.go
@@ -125,7 +125,8 @@ func OnCommand(
 	continueAfter *config.ContinueAfter,
 	execCmd string,
 	execFileCmd string,
-	deleteFatImage bool) {
+	deleteFatImage bool,
+	sensorLogLevel string) {
 
 	const cmdName = Name
 	logger := log.WithFields(log.Fields{"app": appName, "command": cmdName})
@@ -872,6 +873,7 @@ func OnCommand(
 		doIncludeCertPKDirs,
 		selectedNetworks,
 		gparams.Debug,
+		sensorLogLevel,
 		gparams.InContainer,
 		true,
 		prefix)

--- a/pkg/app/master/commands/profile/cli.go
+++ b/pkg/app/master/commands/profile/cli.go
@@ -405,7 +405,8 @@ var CLI = cli.Command{
 			doUseLocalMounts,
 			doUseSensorVolume,
 			//doKeepTmpArtifacts,
-			continueAfter)
+			continueAfter,
+			ctx.GlobalString(commands.FlagLogLevel))
 
 		return nil
 	},

--- a/pkg/app/master/commands/profile/cli.go
+++ b/pkg/app/master/commands/profile/cli.go
@@ -406,7 +406,8 @@ var CLI = cli.Command{
 			doUseSensorVolume,
 			//doKeepTmpArtifacts,
 			continueAfter,
-			ctx.GlobalString(commands.FlagLogLevel))
+			ctx.GlobalString(commands.FlagLogLevel),
+			ctx.GlobalString(commands.FlagLogFormat))
 
 		return nil
 	},

--- a/pkg/app/master/commands/profile/handler.go
+++ b/pkg/app/master/commands/profile/handler.go
@@ -85,7 +85,8 @@ func OnCommand(
 	doUseLocalMounts bool,
 	doUseSensorVolume string,
 	//doKeepTmpArtifacts bool,
-	continueAfter *config.ContinueAfter) {
+	continueAfter *config.ContinueAfter,
+	sensorLogLevel string) {
 	const cmdName = Name
 	logger := log.WithFields(log.Fields{"app": appName, "command": cmdName})
 	prefix := fmt.Sprintf("cmd=%s", cmdName)
@@ -264,6 +265,7 @@ func OnCommand(
 		nil,   //selectedNetNames
 		//nil,
 		gparams.Debug,
+		sensorLogLevel,
 		gparams.InContainer,
 		true,
 		prefix)

--- a/pkg/app/master/commands/profile/handler.go
+++ b/pkg/app/master/commands/profile/handler.go
@@ -86,7 +86,8 @@ func OnCommand(
 	doUseSensorVolume string,
 	//doKeepTmpArtifacts bool,
 	continueAfter *config.ContinueAfter,
-	sensorLogLevel string) {
+	logLevel string,
+	logFormat string) {
 	const cmdName = Name
 	logger := log.WithFields(log.Fields{"app": appName, "command": cmdName})
 	prefix := fmt.Sprintf("cmd=%s", cmdName)
@@ -265,7 +266,8 @@ func OnCommand(
 		nil,   //selectedNetNames
 		//nil,
 		gparams.Debug,
-		sensorLogLevel,
+		logLevel,
+		logFormat,
 		gparams.InContainer,
 		true,
 		prefix)

--- a/pkg/app/master/inspectors/container/container_inspector.go
+++ b/pkg/app/master/inspectors/container/container_inspector.go
@@ -122,6 +122,7 @@ type Inspector struct {
 	SelectedNetworks      map[string]NetNameInfo
 	DoDebug               bool
 	LogLevel              string
+	LogFormat             string
 	PrintState            bool
 	PrintPrefix           string
 	InContainer           bool
@@ -188,6 +189,7 @@ func NewInspector(
 	//serviceAliases []string,
 	doDebug bool,
 	logLevel string,
+	logFormat string,
 	inContainer bool,
 	printState bool,
 	printPrefix string) (*Inspector, error) {
@@ -233,6 +235,7 @@ func NewInspector(
 		SelectedNetworks:      selectedNetworks,
 		DoDebug:               doDebug,
 		LogLevel:              logLevel,
+		LogFormat:             logFormat,
 		PrintState:            printState,
 		PrintPrefix:           printPrefix,
 		InContainer:           inContainer,
@@ -500,6 +503,10 @@ func (i *Inspector) RunContainer() error {
 
 	if i.LogLevel != "" {
 		containerCmd = append(containerCmd, "-log-level", i.LogLevel)
+	}
+
+	if i.LogFormat != "" {
+		containerCmd = append(containerCmd, "-log-format", i.LogFormat)
 	}
 
 	i.ContainerName = fmt.Sprintf(ContainerNamePat, os.Getpid(), time.Now().UTC().Format("20060102150405"))

--- a/pkg/app/master/inspectors/container/container_inspector.go
+++ b/pkg/app/master/inspectors/container/container_inspector.go
@@ -121,6 +121,7 @@ type Inspector struct {
 	DoIncludeCertPKDirs   bool
 	SelectedNetworks      map[string]NetNameInfo
 	DoDebug               bool
+	LogLevel              string
 	PrintState            bool
 	PrintPrefix           string
 	InContainer           bool
@@ -186,6 +187,7 @@ func NewInspector(
 	selectedNetworks map[string]NetNameInfo,
 	//serviceAliases []string,
 	doDebug bool,
+	logLevel string,
 	inContainer bool,
 	printState bool,
 	printPrefix string) (*Inspector, error) {
@@ -230,6 +232,7 @@ func NewInspector(
 		DoIncludeCertPKDirs:   doIncludeCertPKDirs,
 		SelectedNetworks:      selectedNetworks,
 		DoDebug:               doDebug,
+		LogLevel:              logLevel,
 		PrintState:            printState,
 		PrintPrefix:           printPrefix,
 		InContainer:           inContainer,
@@ -493,6 +496,10 @@ func (i *Inspector) RunContainer() error {
 	var containerCmd []string
 	if i.DoDebug {
 		containerCmd = append(containerCmd, "-d")
+	}
+
+	if i.LogLevel != "" {
+		containerCmd = append(containerCmd, "-log-level", i.LogLevel)
 	}
 
 	i.ContainerName = fmt.Sprintf(ContainerNamePat, os.Getpid(), time.Now().UTC().Format("20060102150405"))

--- a/pkg/app/sensor/app.go
+++ b/pkg/app/sensor/app.go
@@ -101,11 +101,13 @@ func startMonitor(errorCh chan error,
 var (
 	enableDebug  bool
 	logLevelName string
+	logFormat    string
 )
 
 func init() {
 	flag.BoolVar(&enableDebug, "d", false, "enable debug logging")
 	flag.StringVar(&logLevelName, "log-level", "info", "set the logging level ('debug', 'info' (default), 'warn', 'error', 'fatal', 'panic')")
+	flag.StringVar(&logFormat, "log-format", "text", "set the format used by logs ('text' (default), or 'json')")
 }
 
 /////////
@@ -114,7 +116,8 @@ func init() {
 func Run() {
 	flag.Parse()
 
-	setLogLevel(enableDebug, logLevelName)
+	err := configureLogger(enableDebug, logLevelName, logFormat)
+	errutil.FailOn(err)
 
 	activeCaps, maxCaps, err := sysenv.Capabilities(0)
 	log.Debugf("sensor: uid=%v euid=%v", os.Getuid(), os.Geteuid())

--- a/pkg/app/sensor/app.go
+++ b/pkg/app/sensor/app.go
@@ -98,10 +98,14 @@ func startMonitor(errorCh chan error,
 
 /////////
 
-var enableDebug bool
+var (
+	enableDebug  bool
+	logLevelName string
+)
 
 func init() {
 	flag.BoolVar(&enableDebug, "d", false, "enable debug logging")
+	flag.StringVar(&logLevelName, "log-level", "info", "set the logging level ('debug', 'info' (default), 'warn', 'error', 'fatal', 'panic')")
 }
 
 /////////
@@ -110,9 +114,7 @@ func init() {
 func Run() {
 	flag.Parse()
 
-	if enableDebug {
-		log.SetLevel(log.DebugLevel)
-	}
+	setLogLevel(enableDebug, logLevelName)
 
 	activeCaps, maxCaps, err := sysenv.Capabilities(0)
 	log.Debugf("sensor: uid=%v euid=%v", os.Getuid(), os.Geteuid())

--- a/pkg/app/sensor/logger.go
+++ b/pkg/app/sensor/logger.go
@@ -1,0 +1,35 @@
+// +build linux
+
+package app
+
+import log "github.com/sirupsen/logrus"
+
+func setLogLevel(enableDebug bool, logLevelName string) {
+	if enableDebug {
+		log.SetLevel(log.DebugLevel)
+		return
+	}
+
+	var logLevel log.Level
+
+	switch logLevelName {
+	case "trace":
+		logLevel = log.TraceLevel
+	case "debug":
+		logLevel = log.DebugLevel
+	case "info":
+		logLevel = log.InfoLevel
+	case "warn":
+		logLevel = log.WarnLevel
+	case "error":
+		logLevel = log.ErrorLevel
+	case "fatal":
+		logLevel = log.FatalLevel
+	case "panic":
+		logLevel = log.PanicLevel
+	default:
+		log.Fatalf("unknown log-level %q", logLevelName)
+	}
+
+	log.SetLevel(logLevel)
+}

--- a/pkg/app/sensor/logger.go
+++ b/pkg/app/sensor/logger.go
@@ -2,17 +2,46 @@
 
 package app
 
-import log "github.com/sirupsen/logrus"
+import (
+	"fmt"
 
-func setLogLevel(enableDebug bool, logLevelName string) {
+	log "github.com/sirupsen/logrus"
+)
+
+func configureLogger(enableDebug bool, levelName, format string) error {
+	if err := setLogLevel(enableDebug, levelName); err != nil {
+		return fmt.Errorf("failed to set log-level: %v", err)
+	}
+
+	if err := setLogFormat(format); err != nil {
+		return fmt.Errorf("failed to set log format: %v", err)
+	}
+
+	return nil
+}
+
+func setLogFormat(format string) error {
+	switch format {
+	case "text":
+		log.SetFormatter(&log.TextFormatter{DisableColors: true})
+	case "json":
+		log.SetFormatter(&log.JSONFormatter{})
+	default:
+		return fmt.Errorf("unknown log-format %q", format)
+	}
+
+	return nil
+}
+
+func setLogLevel(enableDebug bool, levelName string) error {
 	if enableDebug {
 		log.SetLevel(log.DebugLevel)
-		return
+		return nil
 	}
 
 	var logLevel log.Level
 
-	switch logLevelName {
+	switch levelName {
 	case "trace":
 		logLevel = log.TraceLevel
 	case "debug":
@@ -28,8 +57,9 @@ func setLogLevel(enableDebug bool, logLevelName string) {
 	case "panic":
 		logLevel = log.PanicLevel
 	default:
-		log.Fatalf("unknown log-level %q", logLevelName)
+		return fmt.Errorf("unknown log-level %q", levelName)
 	}
 
 	log.SetLevel(logLevel)
+	return nil
 }


### PR DESCRIPTION
[Fixes-254](https://github.com/docker-slim/docker-slim/issues/254)
==================================================================

What
===============
Propagating `log-level` and `log-format` CLI flags from **docker-slim** to **docker-slim-sensor**

Why
===============
Maintain CLI logging configuration consistency among main and internal apps

How Tested
===============
Tested locally by running the following commands:

### Build
```shell

$ ./docker-slim --log-level=<level> --log-format=<format> build my/sample-node-app --http-probe=false --show-clogs --show-blogs --use-local-mounts

$ ./docker-slim --debug --log-format=<format> build my/sample-node-app --http-probe=false --show-clogs --show-blogs --use-local-mounts
```

### Profile
```shell
$ ./docker-slim --log-level=<level> --log-format=<format> profile my/sample-node-app --http-probe=false --show-clogs --use-local-mounts

$ ./docker-slim --debug  --log-format=<format> profile my/sample-node-app --http-probe=false --show-clogs --use-local-mounts
```


