### PR TITLE
fix(probe): check error of NewRequest in probe loop

### DIFF
--- a/pkg/app/master/inspectors/container/probes/http/custom_probe.go
+++ b/pkg/app/master/inspectors/container/probes/http/custom_probe.go
@@ -423,6 +423,11 @@ func (p *CustomProbe) Start() {
 
 					for i := 0; i < maxRetryCount; i++ {
 						req, err := http.NewRequest(cmd.Method, addr, reqBody)
+						if err != nil {
+							p.xc.Out.Error("HTTP probe - construct request error - %v", err.Error())
+							// Break since the same args are passed to NewRequest() on each loop.
+							break
+						}
 						for _, hline := range cmd.Headers {
 							hparts := strings.SplitN(hline, ":", 2)
 							if len(hparts) != 2 {

--- a/pkg/app/master/inspectors/container/probes/http/wsclient.go
+++ b/pkg/app/master/inspectors/container/probes/http/wsclient.go
@@ -184,7 +184,6 @@ func (wc *WebsocketClient) Disconnect() error {
 		if err != nil {
 			log.Debugf("WebsocketClient.Disconnect: conn.WriteMessage(websocket.CloseMessage) error=%v", err)
 			return err
-			fmt.Print("write close err: %v\n", err)
 		}
 
 		//TODO: should wait for the 'websocket: close 1000 (normal)' read error


### PR DESCRIPTION
What
===============
Error is not checked.

Why
===============
Safe construction of an `*http.Request`.

How Tested
===============
No test needed (in my opinion).

