### PR TITLE
feat(probe): implement basic FastCGI support in HTTP probe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ build:  ## build docker-slim
 build_m1:  ## build docker-slim
 	'$(CURDIR)/scripts/src.build.m1.sh'
 
+build_dev:  ## build docker-slim for development (quickly), in bin/
+	'$(CURDIR)/scripts/src.build.quick.sh'
+
 fmt:  ## format all golang files
 	'$(CURDIR)/scripts/src.fmt.sh'
 
@@ -29,4 +32,4 @@ tools: ## install necessary tools
 clean: ## clean up
 	'$(CURDIR)/scripts/src.cleanup.sh'
 
-.PHONY: default help build_in_docker build_m1_in_docker build build_m1 fmt inspect tools clean
+.PHONY: default help build_in_docker build_m1_in_docker build build_m1 build_dev fmt inspect tools clean

--- a/pkg/app/master/commands/build/handler.go
+++ b/pkg/app/master/commands/build/handler.go
@@ -997,7 +997,6 @@ func OnCommand(
 	if err != nil && containerInspector.DoShowContainerLogs {
 		containerInspector.ShowContainerLogs()
 	}
-
 	xc.FailOn(err)
 
 	containerName := containerInspector.ContainerName

--- a/pkg/app/master/config/config.go
+++ b/pkg/app/master/config/config.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 )
 
 // ContainerOverrides provides a set of container field overrides
@@ -114,6 +114,33 @@ type HTTPProbeCmd struct {
 	Username string   `json:"username"`
 	Password string   `json:"password"`
 	Crawl    bool     `json:"crawl"`
+
+	FastCGI *FastCGIProbeWrapperConfig `json:"fastcgi,omitempty"`
+}
+
+// FastCGI permits fine-grained configuration of the fastcgi RoundTripper.
+type FastCGIProbeWrapperConfig struct {
+	// Root is the fastcgi root directory.
+	// Defaults to the root directory of the container.
+	Root string `json:"root,omitempty"`
+
+	// The path in the URL will be split into two, with the first piece ending
+	// with the value of SplitPath. The first piece will be assumed as the
+	// actual resource (CGI script) name, and the second piece will be set to
+	// PATH_INFO for the CGI script to use.
+	SplitPath []string `json:"split_path,omitempty"`
+
+	// Extra environment variables.
+	EnvVars map[string]string `json:"env,omitempty"`
+
+	// The duration used to set a deadline when connecting to an upstream.
+	DialTimeout time.Duration `json:"dial_timeout,omitempty"`
+
+	// The duration used to set a deadline when reading from the FastCGI server.
+	ReadTimeout time.Duration `json:"read_timeout,omitempty"`
+
+	// The duration used to set a deadline when sending to the FastCGI server.
+	WriteTimeout time.Duration `json:"write_timeout,omitempty"`
 }
 
 // HTTPProbeCmds is a list of HTTPProbeCmd instances

--- a/pkg/app/master/inspectors/container/container_inspector.go
+++ b/pkg/app/master/inspectors/container/container_inspector.go
@@ -874,16 +874,12 @@ func (i *Inspector) RunContainer() error {
 	}
 
 	if i.PrintState {
-		var containerIP string
-		if i.ContainerInfo.NetworkSettings != nil {
-			containerIP = i.ContainerInfo.NetworkSettings.IPAddress
-		}
 		i.xc.Out.Info("container",
 			ovars{
 				"status": "running",
 				"name":   containerInfo.Name,
 				"id":     i.ContainerID,
-				"ip":     containerIP,
+				"ip":     i.ContainerInfo.NetworkSettings.IPAddress,
 			})
 	}
 

--- a/pkg/app/master/inspectors/container/probes/http/custom_probe.go
+++ b/pkg/app/master/inspectors/container/probes/http/custom_probe.go
@@ -1,9 +1,9 @@
 package http
 
 import (
-	"fmt"
-	//"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -19,15 +19,16 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/docker-slim/docker-slim/pkg/app"
-	//"github.com/docker-slim/docker-slim/pkg/app/master/commands"
 	"github.com/docker-slim/docker-slim/pkg/app/master/config"
 	"github.com/docker-slim/docker-slim/pkg/app/master/inspectors/container"
 )
 
 const (
 	probeRetryCount = 5
-	httpPortStr     = "80"
-	httpsPortStr    = "443"
+
+	defaultHTTPPortStr    = "80"
+	defaultHTTPSPortStr   = "443"
+	defaultFastCGIPortStr = "9000"
 )
 
 type ovars = app.OutVars
@@ -261,8 +262,8 @@ func (p *CustomProbe) Start() {
 			return -1
 		}
 
-		httpIdx := findIdx(p.Ports, httpPortStr)
-		httpsIdx := findIdx(p.Ports, httpsPortStr)
+		httpIdx := findIdx(p.Ports, defaultHTTPPortStr)
+		httpsIdx := findIdx(p.Ports, defaultHTTPSPortStr)
 		if httpIdx != -1 && httpsIdx != -1 && httpsIdx < httpIdx {
 			//want to probe http first
 			log.Debugf("http.probe - swapping http and https ports (http=%v <-> https=%v)",
@@ -327,13 +328,36 @@ func (p *CustomProbe) Start() {
 					rbSeeker = strBody
 				}
 
+				// TODO: need a smarter and more dynamic way to determine the actual protocol type
+
+				// Set up FastCGI defaults if the default CGI port is used without a FastCGI config.
+				if port == defaultFastCGIPortStr && cmd.FastCGI == nil {
+					log.Debugf("HTTP probe - FastCGI default port (%s) used, setting up HTTP probe FastCGI wrapper defaults")
+
+					// Typicall the entrypoint into a PHP app.
+					if cmd.Resource == "/" {
+						cmd.Resource = "/index.php"
+					}
+
+					// SplitPath is typically on the first .php path element.
+					var splitPath []string
+					if phpIdx := strings.Index(cmd.Resource, ".php"); phpIdx != -1 {
+						splitPath = []string{cmd.Resource[:phpIdx+4]}
+					}
+
+					cmd.FastCGI = &config.FastCGIProbeWrapperConfig{
+						// /var/www is a typical root for PHP indices.
+						Root:      "/var/www",
+						SplitPath: splitPath,
+					}
+				}
+
 				var protocols []string
 				if cmd.Protocol == "" {
-					//need a smarter and more dynamic way to determine the actual protocol type
 					switch port {
-					case httpPortStr:
+					case defaultHTTPPortStr:
 						protocols = []string{config.ProtoHTTP}
-					case httpsPortStr:
+					case defaultHTTPSPortStr:
 						protocols = []string{config.ProtoHTTPS}
 					default:
 						protocols = []string{config.ProtoHTTP, config.ProtoHTTPS}
@@ -424,34 +448,31 @@ func (p *CustomProbe) Start() {
 						continue
 					}
 
-					client := getHTTPClient(proto)
+					var client *http.Client
+					switch {
+					case cmd.FastCGI != nil:
+						log.Debug("HTTP probe - FastCGI embedded proxy configured")
+						client = getFastCGIClient(cmd.FastCGI)
+					default:
+						var err error
+						if client, err = getHTTPClient(proto); err != nil {
+							p.xc.Out.Error("HTTP probe - construct client error - %v", err.Error())
+							continue
+						}
+					}
+
 					baseAddr := getHTTPAddr(proto, targetHost, port)
+					// TODO: cmd.Resource may need to be a part of cmd.FastCGI instead.
 					addr := fmt.Sprintf("%s%s", baseAddr, cmd.Resource)
 
+					req, err := newHTTPRequestFromCmd(cmd, addr, reqBody)
+					if err != nil {
+						p.xc.Out.Error("HTTP probe - construct request error - %v", err.Error())
+						continue
+					}
+
 					for i := 0; i < maxRetryCount; i++ {
-						req, err := http.NewRequest(cmd.Method, addr, reqBody)
-						if err != nil {
-							p.xc.Out.Error("HTTP probe - construct request error - %v", err.Error())
-							// Break since the same args are passed to NewRequest() on each loop.
-							break
-						}
-						for _, hline := range cmd.Headers {
-							hparts := strings.SplitN(hline, ":", 2)
-							if len(hparts) != 2 {
-								log.Debugf("ignoring malformed header (%v)", hline)
-								continue
-							}
-
-							hname := strings.TrimSpace(hparts[0])
-							hvalue := strings.TrimSpace(hparts[1])
-							req.Header.Add(hname, hvalue)
-						}
-
-						if (cmd.Username != "") || (cmd.Password != "") {
-							req.SetBasicAuth(cmd.Username, cmd.Password)
-						}
-
-						res, err := client.Do(req)
+						res, err := client.Do(req.Clone(context.Background()))
 						p.CallCount++
 						rbSeeker.Seek(0, 0)
 
@@ -487,44 +508,34 @@ func (p *CustomProbe) Start() {
 							p.OkCount++
 
 							if p.OkCount == 1 {
-								//fetch the API spec when we know the target is reachable
-								p.loadAPISpecs(proto, targetHost, port)
-
-								//ideally api spec probes should work without http probe commands
-								//for now trigger the api spec probes after the first successful http probe command
-								//and once the api specs are loaded
-								for _, specInfo := range p.APISpecProbes {
-									var apiPrefix string
-									if specInfo.prefixOverride != "" {
-										apiPrefix = specInfo.prefixOverride
-									} else {
-										apiPrefix, err = apiSpecPrefix(specInfo.spec)
-										if err != nil {
-											p.xc.Out.Error("http.probe.api-spec.error.prefix", err.Error())
-											continue
-										}
-									}
-
-									p.probeAPISpecEndpoints(proto, targetHost, port, apiPrefix, specInfo.spec)
+								if len(p.APISpecs) != 0 && len(p.APISpecFiles) != 0 && cmd.FastCGI != nil {
+									p.xc.Out.Info("HTTP probe - API spec probing not implemented for fastcgi")
+								} else {
+									p.probeAPISpecs(proto, targetHost, port)
 								}
 							}
 
 							if cmd.Crawl {
-								p.crawl(proto, targetHost, addr)
+								if cmd.FastCGI != nil {
+									p.xc.Out.Info("HTTP probe - crawling not implemented for fastcgi")
+								} else {
+									p.crawl(proto, targetHost, addr)
+								}
 							}
 							break
 						} else {
 							p.ErrCount++
 
-							if urlErr, ok := err.(*url.Error); ok {
-								if urlErr.Err == io.EOF {
+							urlErr := &url.Error{}
+							if errors.As(err, &urlErr) {
+								if errors.Is(urlErr.Err, io.EOF) {
 									log.Debugf("HTTP probe - target not ready yet (retry again later)...")
 									time.Sleep(notReadyErrorWait * time.Second)
 								} else {
 									log.Debugf("HTTP probe - web error... retry again later...")
 									time.Sleep(webErrorWait * time.Second)
-
 								}
+
 							} else {
 								log.Debugf("HTTP probe - other error... retry again later...")
 								time.Sleep(otherErrorWait * time.Second)
@@ -626,6 +637,30 @@ func (p *CustomProbe) Start() {
 	}()
 }
 
+func (p *CustomProbe) probeAPISpecs(proto, targetHost, port string) {
+	//fetch the API spec when we know the target is reachable
+	p.loadAPISpecs(proto, targetHost, port)
+
+	//ideally api spec probes should work without http probe commands
+	//for now trigger the api spec probes after the first successful http probe command
+	//and once the api specs are loaded
+	for _, specInfo := range p.APISpecProbes {
+		var apiPrefix string
+		if specInfo.prefixOverride != "" {
+			apiPrefix = specInfo.prefixOverride
+		} else {
+			var err error
+			apiPrefix, err = apiSpecPrefix(specInfo.spec)
+			if err != nil {
+				p.xc.Out.Error("http.probe.api-spec.error.prefix", err.Error())
+				continue
+			}
+		}
+
+		p.probeAPISpecEndpoints(proto, targetHost, port, apiPrefix, specInfo.spec)
+	}
+}
+
 // DoneChan returns the 'done' channel for the HTTP probe instance
 func (p *CustomProbe) DoneChan() <-chan struct{} {
 	return p.doneChan
@@ -670,4 +705,29 @@ func exeAppCall(appCall string) error {
 
 	//TODO: process outBuf and errBuf here
 	return nil
+}
+
+func newHTTPRequestFromCmd(cmd config.HTTPProbeCmd, addr string, reqBody io.Reader) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(context.Background(), cmd.Method, addr, reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, hline := range cmd.Headers {
+		hparts := strings.SplitN(hline, ":", 2)
+		if len(hparts) != 2 {
+			log.Debugf("ignoring malformed header (%v)", hline)
+			continue
+		}
+
+		hname := strings.TrimSpace(hparts[0])
+		hvalue := strings.TrimSpace(hparts[1])
+		req.Header.Add(hname, hvalue)
+	}
+
+	if (cmd.Username != "") || (cmd.Password != "") {
+		req.SetBasicAuth(cmd.Username, cmd.Password)
+	}
+
+	return req, nil
 }

--- a/pkg/app/master/inspectors/container/probes/http/internal/client.go
+++ b/pkg/app/master/inspectors/container/probes/http/internal/client.go
@@ -1,0 +1,563 @@
+// This file is a modified version of
+// https://github.com/caddyserver/caddy/blob/44e5e9e/modules/caddyhttp/reverseproxy/fastcgi/client.go
+// Modifications made permit targeting containerized PHP scripts
+// and decouple Caddy dependencies.
+
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Forked Jan. 2015 from http://bitbucket.org/PinIdea/fcgi_client
+// (which is forked from https://code.google.com/p/go-fastcgi-client/).
+// This fork contains several fixes and improvements by Matt Holt and
+// other contributors to the Caddy project.
+
+// Copyright 2012 Junqing Tan <ivan@mysqlab.net> and The Go Authors
+// Use of this source code is governed by a BSD-style
+// Part of source code is from Go fcgi package
+
+package internal
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"mime/multipart"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/textproto"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// FCGIListenSockFileno describes listen socket file number.
+const FCGIListenSockFileno uint8 = 0
+
+// FCGIHeaderLen describes header length.
+const FCGIHeaderLen uint8 = 8
+
+// Version1 describes the version.
+const Version1 uint8 = 1
+
+// FCGINullRequestID describes the null request ID.
+const FCGINullRequestID uint8 = 0
+
+// FCGIKeepConn describes keep connection mode.
+const FCGIKeepConn uint8 = 1
+
+const (
+	// BeginRequest is the begin request flag.
+	BeginRequest uint8 = iota + 1
+	// AbortRequest is the abort request flag.
+	AbortRequest
+	// EndRequest is the end request flag.
+	EndRequest
+	// Params is the parameters flag.
+	Params
+	// Stdin is the standard input flag.
+	Stdin
+	// Stdout is the standard output flag.
+	Stdout
+	// Stderr is the standard error flag.
+	Stderr
+	// Data is the data flag.
+	Data
+	// GetValues is the get values flag.
+	GetValues
+	// GetValuesResult is the get values result flag.
+	GetValuesResult
+	// UnknownType is the unknown type flag.
+	UnknownType
+	// MaxType is the maximum type flag.
+	MaxType = UnknownType
+)
+
+const (
+	// Responder is the responder flag.
+	Responder uint8 = iota + 1
+	// Authorizer is the authorizer flag.
+	Authorizer
+	// Filter is the filter flag.
+	Filter
+)
+
+const (
+	// RequestComplete is the completed request flag.
+	RequestComplete uint8 = iota
+	// CantMultiplexConns is the multiplexed connections flag.
+	CantMultiplexConns
+	// Overloaded is the overloaded flag.
+	Overloaded
+	// UnknownRole is the unknown role flag.
+	UnknownRole
+)
+
+const (
+	// MaxConns is the maximum connections flag.
+	MaxConns string = "MAX_CONNS"
+	// MaxRequests is the maximum requests flag.
+	MaxRequests string = "MAX_REQS"
+	// MultiplexConns is the multiplex connections flag.
+	MultiplexConns string = "MPXS_CONNS"
+)
+
+const (
+	maxWrite = 65500 // 65530 may work, but for compatibility
+	maxPad   = 255
+)
+
+type header struct {
+	Version       uint8
+	Type          uint8
+	ID            uint16
+	ContentLength uint16
+	PaddingLength uint8
+	Reserved      uint8
+}
+
+// for padding so we don't have to allocate all the time
+// not synchronized because we don't care what the contents are
+var pad [maxPad]byte
+
+func (h *header) init(recType uint8, reqID uint16, contentLength int) {
+	h.Version = 1
+	h.Type = recType
+	h.ID = reqID
+	h.ContentLength = uint16(contentLength)
+	h.PaddingLength = uint8(-contentLength & 7)
+}
+
+type record struct {
+	h    header
+	rbuf []byte
+}
+
+func (rec *record) read(r io.Reader) (buf []byte, err error) {
+	if err = binary.Read(r, binary.BigEndian, &rec.h); err != nil {
+		return
+	}
+	if rec.h.Version != 1 {
+		err = errors.New("fcgi: invalid header version")
+		return
+	}
+	if rec.h.Type == EndRequest {
+		err = io.EOF
+		return
+	}
+	n := int(rec.h.ContentLength) + int(rec.h.PaddingLength)
+	if len(rec.rbuf) < n {
+		rec.rbuf = make([]byte, n)
+	}
+	if _, err = io.ReadFull(r, rec.rbuf[:n]); err != nil {
+		return
+	}
+	buf = rec.rbuf[:int(rec.h.ContentLength)]
+
+	return
+}
+
+// FCGIClient implements a FastCGI client, which is a standard for
+// interfacing external applications with Web servers.
+type FCGIClient struct {
+	mutex     sync.Mutex
+	rwc       io.ReadWriteCloser
+	h         header
+	buf       bytes.Buffer
+	stderr    bytes.Buffer
+	keepAlive bool
+	reqID     uint16
+}
+
+// DialWithDialerContext connects to the fcgi responder at the specified network address, using custom net.Dialer
+// and a context.
+// See func net.Dial for a description of the network and address parameters.
+func DialWithDialerContext(ctx context.Context, network, address string, dialer net.Dialer) (fcgi *FCGIClient, err error) {
+	var conn net.Conn
+	conn, err = dialer.DialContext(ctx, network, address)
+	if err != nil {
+		return
+	}
+
+	fcgi = &FCGIClient{
+		rwc:       conn,
+		keepAlive: false,
+		reqID:     1,
+	}
+
+	return
+}
+
+// Close closes fcgi connection
+func (c *FCGIClient) Close() {
+	c.rwc.Close()
+}
+
+func (c *FCGIClient) writeRecord(recType uint8, content []byte) (err error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.buf.Reset()
+	c.h.init(recType, c.reqID, len(content))
+	if err := binary.Write(&c.buf, binary.BigEndian, c.h); err != nil {
+		return err
+	}
+	if _, err := c.buf.Write(content); err != nil {
+		return err
+	}
+	if _, err := c.buf.Write(pad[:c.h.PaddingLength]); err != nil {
+		return err
+	}
+	_, err = c.rwc.Write(c.buf.Bytes())
+	return err
+}
+
+func (c *FCGIClient) writeBeginRequest(role uint16, flags uint8) error {
+	b := [8]byte{byte(role >> 8), byte(role), flags}
+	return c.writeRecord(BeginRequest, b[:])
+}
+
+func (c *FCGIClient) writePairs(recType uint8, pairs map[string]string) error {
+	w := newWriter(c, recType)
+	b := make([]byte, 8)
+	nn := 0
+	for k, v := range pairs {
+		m := 8 + len(k) + len(v)
+		if m > maxWrite {
+			// param data size exceed 65535 bytes"
+			vl := maxWrite - 8 - len(k)
+			v = v[:vl]
+		}
+		n := encodeSize(b, uint32(len(k)))
+		n += encodeSize(b[n:], uint32(len(v)))
+		m = n + len(k) + len(v)
+		if (nn + m) > maxWrite {
+			w.Flush()
+			nn = 0
+		}
+		nn += m
+		if _, err := w.Write(b[:n]); err != nil {
+			return err
+		}
+		if _, err := w.WriteString(k); err != nil {
+			return err
+		}
+		if _, err := w.WriteString(v); err != nil {
+			return err
+		}
+	}
+	w.Close()
+	return nil
+}
+
+func encodeSize(b []byte, size uint32) int {
+	if size > 127 {
+		size |= 1 << 31
+		binary.BigEndian.PutUint32(b, size)
+		return 4
+	}
+	b[0] = byte(size)
+	return 1
+}
+
+// bufWriter encapsulates bufio.Writer but also closes the underlying stream when
+// Closed.
+type bufWriter struct {
+	closer io.Closer
+	*bufio.Writer
+}
+
+func (w *bufWriter) Close() error {
+	if err := w.Writer.Flush(); err != nil {
+		w.closer.Close()
+		return err
+	}
+	return w.closer.Close()
+}
+
+func newWriter(c *FCGIClient, recType uint8) *bufWriter {
+	s := &streamWriter{c: c, recType: recType}
+	w := bufio.NewWriterSize(s, maxWrite)
+	return &bufWriter{s, w}
+}
+
+// streamWriter abstracts out the separation of a stream into discrete records.
+// It only writes maxWrite bytes at a time.
+type streamWriter struct {
+	c       *FCGIClient
+	recType uint8
+}
+
+func (w *streamWriter) Write(p []byte) (int, error) {
+	nn := 0
+	for len(p) > 0 {
+		n := len(p)
+		if n > maxWrite {
+			n = maxWrite
+		}
+		if err := w.c.writeRecord(w.recType, p[:n]); err != nil {
+			return nn, err
+		}
+		nn += n
+		p = p[n:]
+	}
+	return nn, nil
+}
+
+func (w *streamWriter) Close() error {
+	// send empty record to close the stream
+	return w.c.writeRecord(w.recType, nil)
+}
+
+type streamReader struct {
+	c   *FCGIClient
+	buf []byte
+}
+
+func (w *streamReader) Read(p []byte) (n int, err error) {
+
+	if len(p) > 0 {
+		if len(w.buf) == 0 {
+
+			// filter outputs for error log
+			for {
+				rec := &record{}
+				var buf []byte
+				buf, err = rec.read(w.c.rwc)
+				if err != nil {
+					return
+				}
+				// standard error output
+				if rec.h.Type == Stderr {
+					w.c.stderr.Write(buf)
+					continue
+				}
+				w.buf = buf
+				break
+			}
+		}
+
+		n = len(p)
+		if n > len(w.buf) {
+			n = len(w.buf)
+		}
+		copy(p, w.buf[:n])
+		w.buf = w.buf[n:]
+	}
+
+	return
+}
+
+// Do made the request and returns a io.Reader that translates the data read
+// from fcgi responder out of fcgi packet before returning it.
+func (c *FCGIClient) Do(p map[string]string, req io.Reader) (r io.Reader, err error) {
+	err = c.writeBeginRequest(uint16(Responder), 0)
+	if err != nil {
+		return
+	}
+
+	err = c.writePairs(Params, p)
+	if err != nil {
+		return
+	}
+
+	body := newWriter(c, Stdin)
+	if req != nil {
+		_, _ = io.Copy(body, req)
+	}
+	body.Close()
+
+	r = &streamReader{c: c}
+	return
+}
+
+// clientCloser is a io.ReadCloser. It wraps a io.Reader with a Closer
+// that closes FCGIClient connection.
+type clientCloser struct {
+	*FCGIClient
+	io.Reader
+}
+
+func (f clientCloser) Close() error { return f.rwc.Close() }
+
+// Request returns a HTTP Response with Header and Body
+// from fcgi responder
+func (c *FCGIClient) Request(p map[string]string, req io.Reader) (resp *http.Response, err error) {
+	r, err := c.Do(p, req)
+	if err != nil {
+		return
+	}
+
+	rb := bufio.NewReader(r)
+	tp := textproto.NewReader(rb)
+	resp = new(http.Response)
+
+	// Parse the response headers.
+	mimeHeader, err := tp.ReadMIMEHeader()
+	if err != nil && err != io.EOF {
+		return
+	}
+	resp.Header = http.Header(mimeHeader)
+
+	if resp.Header.Get("Status") != "" {
+		statusParts := strings.SplitN(resp.Header.Get("Status"), " ", 2)
+		resp.StatusCode, err = strconv.Atoi(statusParts[0])
+		if err != nil {
+			return
+		}
+		if len(statusParts) > 1 {
+			resp.Status = statusParts[1]
+		}
+
+	} else {
+		resp.StatusCode = http.StatusOK
+	}
+
+	// TODO: fixTransferEncoding ?
+	resp.TransferEncoding = resp.Header["Transfer-Encoding"]
+	resp.ContentLength, _ = strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64)
+
+	if chunked(resp.TransferEncoding) {
+		resp.Body = clientCloser{c, httputil.NewChunkedReader(rb)}
+	} else {
+		resp.Body = clientCloser{c, io.NopCloser(rb)}
+	}
+	return
+}
+
+// Get issues a GET request to the fcgi responder.
+func (c *FCGIClient) Get(p map[string]string, body io.Reader, l int64) (resp *http.Response, err error) {
+
+	p["REQUEST_METHOD"] = "GET"
+	p["CONTENT_LENGTH"] = strconv.FormatInt(l, 10)
+
+	return c.Request(p, body)
+}
+
+// Head issues a HEAD request to the fcgi responder.
+func (c *FCGIClient) Head(p map[string]string) (resp *http.Response, err error) {
+
+	p["REQUEST_METHOD"] = "HEAD"
+	p["CONTENT_LENGTH"] = "0"
+
+	return c.Request(p, nil)
+}
+
+// Options issues an OPTIONS request to the fcgi responder.
+func (c *FCGIClient) Options(p map[string]string) (resp *http.Response, err error) {
+
+	p["REQUEST_METHOD"] = "OPTIONS"
+	p["CONTENT_LENGTH"] = "0"
+
+	return c.Request(p, nil)
+}
+
+// Post issues a POST request to the fcgi responder. with request body
+// in the format that bodyType specified
+func (c *FCGIClient) Post(p map[string]string, method string, bodyType string, body io.Reader, l int64) (resp *http.Response, err error) {
+	if p == nil {
+		p = make(map[string]string)
+	}
+
+	p["REQUEST_METHOD"] = strings.ToUpper(method)
+
+	if len(p["REQUEST_METHOD"]) == 0 || p["REQUEST_METHOD"] == "GET" {
+		p["REQUEST_METHOD"] = "POST"
+	}
+
+	p["CONTENT_LENGTH"] = strconv.FormatInt(l, 10)
+	if len(bodyType) > 0 {
+		p["CONTENT_TYPE"] = bodyType
+	} else {
+		p["CONTENT_TYPE"] = "application/x-www-form-urlencoded"
+	}
+
+	return c.Request(p, body)
+}
+
+// PostForm issues a POST to the fcgi responder, with form
+// as a string key to a list values (url.Values)
+func (c *FCGIClient) PostForm(p map[string]string, data url.Values) (resp *http.Response, err error) {
+	body := bytes.NewReader([]byte(data.Encode()))
+	return c.Post(p, "POST", "application/x-www-form-urlencoded", body, int64(body.Len()))
+}
+
+// PostFile issues a POST to the fcgi responder in multipart(RFC 2046) standard,
+// with form as a string key to a list values (url.Values),
+// and/or with file as a string key to a list file path.
+func (c *FCGIClient) PostFile(p map[string]string, data url.Values, file map[string]string) (resp *http.Response, err error) {
+	buf := &bytes.Buffer{}
+	writer := multipart.NewWriter(buf)
+	bodyType := writer.FormDataContentType()
+
+	for key, val := range data {
+		for _, v0 := range val {
+			err = writer.WriteField(key, v0)
+			if err != nil {
+				return
+			}
+		}
+	}
+
+	for key, val := range file {
+		fd, e := os.Open(val)
+		if e != nil {
+			return nil, e
+		}
+		defer fd.Close()
+
+		part, e := writer.CreateFormFile(key, filepath.Base(val))
+		if e != nil {
+			return nil, e
+		}
+		_, err = io.Copy(part, fd)
+		if err != nil {
+			return
+		}
+	}
+
+	err = writer.Close()
+	if err != nil {
+		return
+	}
+
+	return c.Post(p, "POST", bodyType, buf, int64(buf.Len()))
+}
+
+// SetReadTimeout sets the read timeout for future calls that read from the
+// fcgi responder. A zero value for t means no timeout will be set.
+func (c *FCGIClient) SetReadTimeout(t time.Duration) error {
+	if conn, ok := c.rwc.(net.Conn); ok && t != 0 {
+		return conn.SetReadDeadline(time.Now().Add(t))
+	}
+	return nil
+}
+
+// SetWriteTimeout sets the write timeout for future calls that send data to
+// the fcgi responder. A zero value for t means no timeout will be set.
+func (c *FCGIClient) SetWriteTimeout(t time.Duration) error {
+	if conn, ok := c.rwc.(net.Conn); ok && t != 0 {
+		return conn.SetWriteDeadline(time.Now().Add(t))
+	}
+	return nil
+}
+
+// Checks whether chunked is part of the encodings stack
+func chunked(te []string) bool { return len(te) > 0 && te[0] == "chunked" }

--- a/pkg/app/master/inspectors/container/probes/http/internal/fastcgi.go
+++ b/pkg/app/master/inspectors/container/probes/http/internal/fastcgi.go
@@ -1,0 +1,283 @@
+// This file is a modified version of
+// https://github.com/caddyserver/caddy/blob/44e5e9e/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go
+// Modifications made permit targeting containerized PHP scripts
+// and decouple Caddy dependencies.
+
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var _ http.RoundTripper = &FastCGITransport{}
+
+// FastCGITransport facilitates FastCGI communication.
+type FastCGITransport struct {
+	// Root is the fastcgi root directory.
+	// Defaults to the root directory of the container.
+	Root string
+
+	// The path in the URL will be split into two, with the first piece ending
+	// with the value of SplitPath. The first piece will be assumed as the
+	// actual resource (CGI script) name, and the second piece will be set to
+	// PATH_INFO for the CGI script to use.
+	SplitPath []string
+
+	// Extra environment variables.
+	EnvVars map[string]string
+
+	// The duration used to set a deadline when connecting to an upstream.
+	DialTimeout time.Duration
+
+	// The duration used to set a deadline when reading from the FastCGI server.
+	ReadTimeout time.Duration
+
+	// The duration used to set a deadline when sending to the FastCGI server.
+	WriteTimeout time.Duration
+}
+
+// init sets up t.
+func (t *FastCGITransport) init() {
+	if t.Root == "" {
+		t.Root = "/"
+	}
+}
+
+// RoundTrip implements http.RoundTripper.
+func (t FastCGITransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	t.init()
+
+	env, err := t.buildEnv(r)
+	if err != nil {
+		return nil, fmt.Errorf("building environment: %v", err)
+	}
+
+	network, address := "tcp", r.URL.Host
+
+	if log.IsLevelEnabled(log.DebugLevel) {
+		envJSON, _ := json.Marshal(env)
+		log.Debugf("HTTP probe - FastCGI env - %s", string(envJSON))
+	}
+
+	ctx := r.Context()
+	dialer := net.Dialer{Timeout: t.DialTimeout}
+	fcgiBackend, err := DialWithDialerContext(ctx, network, address, dialer)
+	if err != nil {
+		// TODO: wrap in a special error type if the dial failed, so retries can happen if enabled
+		return nil, fmt.Errorf("dialing backend: %v", err)
+	}
+	// fcgiBackend gets closed when response body is closed (see clientCloser)
+
+	// read/write timeouts
+	if err := fcgiBackend.SetReadTimeout(t.ReadTimeout); err != nil {
+		return nil, fmt.Errorf("setting read timeout: %v", err)
+	}
+	if err := fcgiBackend.SetWriteTimeout(t.WriteTimeout); err != nil {
+		return nil, fmt.Errorf("setting write timeout: %v", err)
+	}
+
+	contentLength := r.ContentLength
+	if contentLength == 0 {
+		contentLength, _ = strconv.ParseInt(r.Header.Get("Content-Length"), 10, 64)
+	}
+
+	var resp *http.Response
+	switch r.Method {
+	case http.MethodHead:
+		resp, err = fcgiBackend.Head(env)
+	case http.MethodGet:
+		resp, err = fcgiBackend.Get(env, r.Body, contentLength)
+	case http.MethodOptions:
+		resp, err = fcgiBackend.Options(env)
+	default:
+		resp, err = fcgiBackend.Post(env, r.Method, r.Header.Get("Content-Type"), r.Body, contentLength)
+	}
+
+	return resp, err
+}
+
+// buildEnv returns a set of CGI environment variables for the request.
+func (t FastCGITransport) buildEnv(r *http.Request) (map[string]string, error) {
+
+	// Separate remote IP and port; more lenient than net.SplitHostPort
+	var ip, port string
+	if idx := strings.LastIndex(r.RemoteAddr, ":"); idx > -1 {
+		ip = r.RemoteAddr[:idx]
+		port = r.RemoteAddr[idx+1:]
+	} else {
+		ip = r.RemoteAddr
+	}
+
+	// Remove [] from IPv6 addresses
+	ip = strings.Replace(ip, "[", "", 1)
+	ip = strings.Replace(ip, "]", "", 1)
+
+	// make sure file root is absolute
+	if !path.IsAbs(t.Root) {
+		return nil, fmt.Errorf("root %q is not absolute", t.Root)
+	}
+	root := t.Root
+
+	fpath := r.URL.Path
+	scriptName := fpath
+
+	docURI := fpath
+	// split "actual path" from "path info" if configured
+	var pathInfo string
+	if splitPos := t.splitPos(fpath); splitPos > -1 {
+		docURI = fpath[:splitPos]
+		pathInfo = fpath[splitPos:]
+
+		// Strip PATH_INFO from SCRIPT_NAME
+		scriptName = strings.TrimSuffix(scriptName, pathInfo)
+	}
+
+	// SCRIPT_FILENAME is the absolute path of SCRIPT_NAME
+	scriptFilename := path.Join(root, scriptName)
+
+	// Ensure the SCRIPT_NAME has a leading slash for compliance with RFC3875
+	// Info: https://tools.ietf.org/html/rfc3875#section-4.1.13
+	if scriptName != "" && !path.IsAbs(scriptName) {
+		scriptName = "/" + scriptName
+	}
+
+	requestScheme := "http"
+	if r.TLS != nil {
+		requestScheme = "https"
+	}
+
+	reqHost, reqPort, err := net.SplitHostPort(r.Host)
+	if err != nil {
+		// whatever, just assume there was no port
+		reqHost = r.Host
+	}
+
+	authUser, _, _ := r.BasicAuth()
+
+	// Some variables are unused but cleared explicitly to prevent
+	// the parent environment from interfering.
+	env := map[string]string{
+		// Variables defined in CGI 1.1 spec
+		"AUTH_TYPE":         "", // Not used
+		"CONTENT_LENGTH":    r.Header.Get("Content-Length"),
+		"CONTENT_TYPE":      r.Header.Get("Content-Type"),
+		"GATEWAY_INTERFACE": "CGI/1.1",
+		"PATH_INFO":         pathInfo,
+		"QUERY_STRING":      r.URL.RawQuery,
+		"REMOTE_ADDR":       ip,
+		"REMOTE_HOST":       ip, // For speed, remote host lookups disabled
+		"REMOTE_PORT":       port,
+		"REMOTE_IDENT":      "", // Not used
+		"REMOTE_USER":       authUser,
+		"REQUEST_METHOD":    r.Method,
+		"REQUEST_SCHEME":    requestScheme,
+		"SERVER_NAME":       reqHost,
+		"SERVER_PROTOCOL":   r.Proto,
+		"SERVER_SOFTWARE":   "docker-slim/v0.0.0",
+
+		// Other variables
+		"DOCUMENT_ROOT": root,
+		"DOCUMENT_URI":  docURI,
+		"HTTP_HOST":     r.Host, // added here, since not always part of headers
+		// "REQUEST_URI":     "",
+		"SCRIPT_FILENAME": scriptFilename,
+		"SCRIPT_NAME":     scriptName,
+	}
+
+	// compliance with the CGI specification requires that
+	// PATH_TRANSLATED should only exist if PATH_INFO is defined.
+	// Info: https://www.ietf.org/rfc/rfc3875 Page 14
+	if pathInfo != "" {
+		env["PATH_TRANSLATED"] = path.Join(root, pathInfo)
+	}
+
+	// compliance with the CGI specification requires that
+	// SERVER_PORT should only exist if it's a valid numeric value.
+	// Info: https://www.ietf.org/rfc/rfc3875 Page 18
+	if reqPort != "" {
+		env["SERVER_PORT"] = reqPort
+	}
+
+	// Some web apps rely on knowing HTTPS or not
+	if r.TLS != nil {
+		env["HTTPS"] = "on"
+		// and pass the protocol details in a manner compatible with apache's mod_ssl
+		// (which is why these have a SSL_ prefix and not TLS_).
+		v, ok := tlsProtocolStrings[r.TLS.Version]
+		if ok {
+			env["SSL_PROTOCOL"] = v
+		}
+		// and pass the cipher suite in a manner compatible with apache's mod_ssl
+		for _, cs := range tls.CipherSuites() {
+			if cs.ID == r.TLS.CipherSuite {
+				env["SSL_CIPHER"] = cs.Name
+				break
+			}
+		}
+	}
+
+	// Add env variables from config (with support for placeholders in values)
+	for key, value := range t.EnvVars {
+		env[key] = value
+	}
+
+	// Add all HTTP headers to env variables
+	for field, val := range r.Header {
+		header := strings.ToUpper(field)
+		header = headerNameReplacer.Replace(header)
+		env["HTTP_"+header] = strings.Join(val, ", ")
+	}
+
+	return env, nil
+}
+
+// splitPos returns the index where path should
+// be split based on t.SplitPath.
+func (t FastCGITransport) splitPos(path string) int {
+	if len(t.SplitPath) == 0 {
+		return 0
+	}
+
+	lowerPath := strings.ToLower(path)
+	for _, split := range t.SplitPath {
+		if idx := strings.Index(lowerPath, strings.ToLower(split)); idx > -1 {
+			return idx + len(split)
+		}
+	}
+	return -1
+}
+
+// Map of supported protocols to Apache ssl_mod format
+// Note that these are slightly different from SupportedProtocols in caddytls/config.go
+var tlsProtocolStrings = map[uint16]string{
+	tls.VersionTLS10: "TLSv1",
+	tls.VersionTLS11: "TLSv1.1",
+	tls.VersionTLS12: "TLSv1.2",
+	tls.VersionTLS13: "TLSv1.3",
+}
+
+var headerNameReplacer = strings.NewReplacer(" ", "_", "-", "_")

--- a/pkg/ipc/channel/channel.go
+++ b/pkg/ipc/channel/channel.go
@@ -466,7 +466,7 @@ func NewCommandClient(addr string, connectWait, connectTimeout, readTimeout, wri
 				return cmdClient, nil
 			}
 
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				log.Debug("channel.NewCommandClient: closed connection.")
 			} else {
 				log.Errorf("channel.NewCommandClient: channel verify error = %v", err)

--- a/scripts/src.build.quick.sh
+++ b/scripts/src.build.quick.sh
@@ -16,8 +16,9 @@ fi
 
 LD_FLAGS="-s -w -X github.com/docker-slim/docker-slim/pkg/version.appVersionTag=${TAG} -X github.com/docker-slim/docker-slim/pkg/version.appVersionRev=${REVISION} -X github.com/docker-slim/docker-slim/pkg/version.appVersionTime=${BUILD_TIME}"
 
-mkdir -p ${BDIR}/dist_linux/
-rm -f ${BDIR}/dist_linux/*
+BINDIR="${BDIR}/bin"
+mkdir -p "$BINDIR"
+rm -f "${BINDIR}/"*
 
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="${LD_FLAGS}" -mod=vendor -o "${BDIR}/dist_linux/docker-slim" "${BDIR}/cmd/docker-slim/main.go"
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="${LD_FLAGS}" -mod=vendor -o "${BDIR}/dist_linux/docker-slim-sensor" "${BDIR}/cmd/docker-slim-sensor/main.go"
+CGO_ENABLED=0 go build -ldflags="${LD_FLAGS}" -mod=vendor -o "${BINDIR}/docker-slim" "${BDIR}/cmd/docker-slim/main.go"
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="${LD_FLAGS}" -mod=vendor -o "${BINDIR}/docker-slim-sensor" "${BDIR}/cmd/docker-slim-sensor/main.go"


### PR DESCRIPTION
[Fixes-265](https://github.com/docker-slim/docker-slim/issues/265)
==================================================================

What
===============
Implement FastCGI support in the HTTP probe, and add configuration options for the FastCGI client.

Why
===============
See #265

How Tested
===============
Run with https://github.com/docker-slim/examples/pull/21.


