### PR TITLE
fix(container_inspector): probe `EXPOSE`'d tcp ports when host networked

### DIFF
--- a/pkg/app/master/config/config.go
+++ b/pkg/app/master/config/config.go
@@ -55,6 +55,9 @@ func NewAppOptionsFromFile(dir string) (*AppOptions, error) {
 	return &result, nil
 }
 
+// TODO: robustly parse `--network`/Network at the CLI level to avoid ambiguity.
+// https://github.com/docker/cli/blob/cf8c4bab6477ef62122bda875f80d8472005010d/opts/network.go#L35
+
 // ContainerOverrides provides a set of container field overrides
 // It can also be used to update the image instructions when
 // the "image-overrides" flag is provided


### PR DESCRIPTION
What
===============
Refactoring port setup in container inspector so that `--network host` mode can HTTP probe properly

Why
===============
Ports are not exposed on containers run with `--network host` as with bridge networks. Instead the application listening on a port has direct access to the host's network. Therefore `docker-slim` should use the loopback IP `127.0.0.1` as the host IP when in that mode. This is how the IPC probe currently works for the special `65501` and `65502` ports; this PR extends that functionality to "published" ports for host-networked containers (ex. when run with `--publish-exposed-ports`.

How Tested
===============
Trying `docker-slim build --network host --target nginx:latest --publish-exposed-ports` on master and with this branch.


