### PR TITLE
Fix sensor's signal handling in ptrace monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 dist_linux*.tar.gz
 dist_mac.zip
 .idea
+*.swp

--- a/pkg/monitor/ptrace/ptrace.go
+++ b/pkg/monitor/ptrace/ptrace.go
@@ -518,9 +518,8 @@ func (app *App) collect() {
 	mainExiting := false
 	waitFor := -1
 	doSyscall := true
+	callSig := 0
 	for {
-		var callSig int
-
 		select {
 		case <-app.StopCh:
 			log.Debug("ptrace.App.collect: stop (exiting)")
@@ -572,8 +571,8 @@ func (app *App) collect() {
 			return
 		}
 
+		callSig = 0 // reset
 		terminated := false
-		stopped := false
 		eventStop := false
 		handleCall := false
 		eventCode := 0
@@ -586,7 +585,6 @@ func (app *App) collect() {
 			terminated = true
 			statusCode = int(ws.Signal())
 		case ws.Stopped():
-			stopped = true
 			statusCode = int(ws.StopSignal())
 			if statusCode == int(syscall.SIGTRAP|traceSysGoodStatusBit) {
 				handleCall = true
@@ -752,10 +750,6 @@ func (app *App) collect() {
 						app.cmd.Process.Pid, app.pgid, wpid)
 				}
 			}
-		}
-
-		if stopped {
-			callSig = statusCode
 		}
 
 		doSyscall = true

--- a/scripts/src.build.quick.sh
+++ b/scripts/src.build.quick.sh
@@ -18,7 +18,7 @@ LD_FLAGS="-s -w -X github.com/docker-slim/docker-slim/pkg/version.appVersionTag=
 
 BINDIR="${BDIR}/bin"
 mkdir -p "$BINDIR"
-rm -f "${BINDIR}/"*
+rm -rf "${BINDIR}/"*
 
 CGO_ENABLED=0 go build -ldflags="${LD_FLAGS}" -mod=vendor -o "${BINDIR}/docker-slim" "${BDIR}/cmd/docker-slim/main.go"
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="${LD_FLAGS}" -mod=vendor -o "${BINDIR}/docker-slim-sensor" "${BDIR}/cmd/docker-slim-sensor/main.go"


### PR DESCRIPTION
When the ptrace monitor intercepts a signal, it should be returned
to the origin process on the next loop iteration to continue the
process' execution. Due to a wrong local variable scope, the actual
signal code was lost (i.e., reset to 0) between two consequent loop
iterations. This led to processes getting stuck in the container
under the docker-slim control.

Here is the small repro. Build the following container:

```
FROM openjdk:11

COPY <<EOF /opt/start.sh
set -ex
java -version
EOF

RUN chmod +x /opt/start.sh

CMD ["/opt/start.sh"]
```

...And try optimizing it using using the next command:

```
./docker-slim --log-level trace build --http-probe-off --show-clogs <tag>
```

The `java -version` command would never exit before this commit.

[Fixes-###](https://github.com/docker-slim/docker-slim/issues/###)
==================================================================

What
===============


Why
===============


How Tested
===============


