### PR TITLE
Add debug command - Kubecon 2022 Hackathon

### DIFF
--- a/pkg/app/master/commands/debug/cli.go
+++ b/pkg/app/master/commands/debug/cli.go
@@ -13,14 +13,41 @@ import (
 
 const (
 	Name  = "debug"
-	Usage = "Debug target container"
+	Usage = "Debug the target container image from a debug container"
 	Alias = "dbg"
+
+	FlagDebugImage    = "debug-image"
+	FlagDebugImageCmd = "debug-image-cmd"
+
+	DefaultDebugImage    = "nicolaka/netshoot"
+	DefaultDebugImageCmd = "/bin/bash"
 )
+
+type CommandParams struct {
+	/// the running container which we want to attach to
+	TargetRef string
+	/// the name/id of the container image used for debugging
+	DebugContainerImage string
+	/// CMD used for launching the debugging image
+	DebugContainerImageCmd string
+}
 
 var CLI = &cli.Command{
 	Name:    Name,
 	Aliases: []string{Alias},
 	Usage:   Usage,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:        FlagDebugImage,
+			DefaultText: DefaultDebugImage,
+			Required:    false,
+		},
+		&cli.StringFlag{
+			Name:        FlagDebugImageCmd,
+			DefaultText: DefaultDebugImageCmd,
+			Required:    false,
+		},
+	},
 	Action: func(ctx *cli.Context) error {
 		if ctx.Args().Len() < 1 {
 			fmt.Printf("docker-slim[%s]: missing target info...\n\n", Name)
@@ -33,14 +60,35 @@ var CLI = &cli.Command{
 			return err
 		}
 
-		targetRef := ctx.Args().First()
+		commandParams := &CommandParams{
+			TargetRef:              ctx.String(commands.FlagTarget),
+			DebugContainerImage:    ctx.String(FlagDebugImage),
+			DebugContainerImageCmd: ctx.String(FlagDebugImageCmd),
+		}
 
 		xc := app.NewExecutionContext(Name)
+
+		if commandParams.TargetRef == "" {
+			if ctx.Args().Len() < 1 {
+				xc.Out.Error("param.target", "missing target")
+				cli.ShowCommandHelp(ctx, Name)
+				return nil
+			} else {
+				commandParams.TargetRef = ctx.Args().First()
+			}
+		}
+
+		if commandParams.DebugContainerImage == "" {
+			commandParams.DebugContainerImage = DefaultDebugImage
+		}
+		if commandParams.DebugContainerImageCmd == "" {
+			commandParams.DebugContainerImageCmd = DefaultDebugImageCmd
+		}
 
 		OnCommand(
 			xc,
 			gcvalues,
-			targetRef)
+			commandParams)
 
 		return nil
 	},

--- a/pkg/app/master/commands/debug/handler.go
+++ b/pkg/app/master/commands/debug/handler.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/docker-slim/docker-slim/pkg/app"
 	"github.com/docker-slim/docker-slim/pkg/app/master/commands"
+	"github.com/docker-slim/docker-slim/pkg/app/master/container"
 	"github.com/docker-slim/docker-slim/pkg/app/master/docker/dockerclient"
+	"github.com/docker-slim/docker-slim/pkg/app/master/inspectors/image"
 	"github.com/docker-slim/docker-slim/pkg/app/master/version"
 	"github.com/docker-slim/docker-slim/pkg/command"
 	"github.com/docker-slim/docker-slim/pkg/report"
@@ -24,7 +26,7 @@ type ovars = app.OutVars
 func OnCommand(
 	xc *app.ExecutionContext,
 	gparams *commands.GenericParams,
-	targetRef string) {
+	commandParams *CommandParams) {
 	logger := log.WithFields(log.Fields{"app": appName, "command": Name})
 	prefix := fmt.Sprintf("cmd=%s", Name)
 
@@ -36,7 +38,9 @@ func OnCommand(
 	xc.Out.State("started")
 	xc.Out.Info("params",
 		ovars{
-			"target": targetRef,
+			"target":          commandParams.TargetRef,
+			"debug-image":     commandParams.DebugContainerImage,
+			"debug-image-cmd": commandParams.DebugContainerImageCmd,
 		})
 
 	client, err := dockerclient.New(gparams.ClientConfig)
@@ -65,6 +69,47 @@ func OnCommand(
 	if gparams.Debug {
 		version.Print(prefix, logger, client, false, gparams.InContainer, gparams.IsDSImage)
 	}
+
+	imageInspector, err := image.NewInspector(client, commandParams.DebugContainerImage)
+	options := container.ExecutionOptions{
+		Cmd:      []string{commandParams.DebugContainerImageCmd},
+		Terminal: true,
+	}
+	if imageInspector.NoImage() {
+		err := imageInspector.Pull(true, "", "", "")
+		errutil.FailOn(err)
+	}
+
+	exe, err := container.NewExecution(
+		xc,
+		logger,
+		client,
+		commandParams.DebugContainerImage,
+		&options,
+		nil,
+		true,
+		true)
+
+	// attach network, IPC & PIDs, essentially this is run --network container:golang_service --pid container:golang_service --ipc container:golang_service
+	mode := fmt.Sprintf("container:%s", commandParams.TargetRef)
+	fmt.Println("mode: ")
+	fmt.Println(mode)
+	exe.IpcMode = mode
+	exe.NetworkMode = mode
+	exe.PidMode = mode
+
+	errutil.FailOn(err)
+
+	err = exe.Start()
+	errutil.FailOn(err)
+
+	_, err = exe.Wait()
+	errutil.FailOn(err)
+
+	defer func() {
+		err = exe.Cleanup()
+		errutil.WarnOn(err)
+	}()
 
 	xc.Out.State("completed")
 	cmdReport.State = command.StateCompleted

--- a/pkg/app/master/container/execution.go
+++ b/pkg/app/master/container/execution.go
@@ -86,12 +86,20 @@ type ExecutionIO struct {
 }
 
 type Execution struct {
-	ContainerInfo     *dockerapi.Container
-	ContainerName     string
-	ContainerID       string
-	State             ExecutionState
-	Crashed           bool
-	StopTimeout       uint
+	ContainerInfo *dockerapi.Container
+	ContainerName string
+	ContainerID   string
+	State         ExecutionState
+	Crashed       bool
+	StopTimeout   uint
+
+	/// the following fields are forwarded to dockerapi.HostConfig and take
+	/// the same parameters as docker's `--pid`, `--network` and `--ipc` CLI
+	/// flags
+	PidMode     string
+	NetworkMode string
+	IpcMode     string
+
 	imageRef          string
 	APIClient         *dockerapi.Client
 	options           *ExecutionOptions
@@ -149,7 +157,11 @@ func NewExecution(
 func (ref *Execution) Start() error {
 	ref.ContainerName = fmt.Sprintf(ContainerNamePat, os.Getpid(), time.Now().UTC().Format("20060102150405"))
 
-	hostConfig := &dockerapi.HostConfig{}
+	hostConfig := &dockerapi.HostConfig{
+		NetworkMode: ref.NetworkMode,
+		PidMode:     ref.PidMode,
+		IpcMode:     ref.IpcMode,
+	}
 
 	containerOptions := dockerapi.CreateContainerOptions{
 		Name: ref.ContainerName,


### PR DESCRIPTION
What
===============

This PR adds a very simple debug command, which creates a new container and attaches its IPC, namespaces and network to another running container for simpler debugging of slimmed down container images.

Why
===============

It simplifies the debugging of minified container images.


How Tested
===============

Manually