### PR TITLE
Make sensor tolerate 'no such process' errors during tracing

### DIFF
--- a/.github/workflows/acceptance-testing-bats.yml
+++ b/.github/workflows/acceptance-testing-bats.yml
@@ -1,20 +1,18 @@
----
-name: Continous integration of docker-slim
-
+name: Acceptance testing (using bats tests)
 on:
   push:
     branches:
-      - "master"
+      - master
   pull_request:
-
+    branches:
+      - master
+    types: [opened, synchronize, closed]
 jobs:
   test:
     strategy:
       matrix:
-        go: ['1.15', '1.16', '1.17', '1.18']
+        go: ['1.15', '1.18']
     runs-on: 'ubuntu-latest'
-    name: integration tests
-
     steps:
       - uses: actions/cache@v3
         with:
@@ -24,6 +22,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -33,8 +32,8 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
-      - name: build docker-slim
+      - name: Build DockerSlim (quick dev)
         run: make build_dev
 
-      - name: run the bats integration tests
+      - name: Run the bats test suite
         run: ./test/bats/bin/bats test/debug.bats

--- a/.github/workflows/acceptance-testing-e2e.yml
+++ b/.github/workflows/acceptance-testing-e2e.yml
@@ -1,10 +1,12 @@
-name: build-and-test
+name: Acceptance testing (using e2e tests from docker-slim/examples)
 on:
   push:
     branches:
       - master
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  pull_request:
+    branches:
+      - master
+    types: [opened, synchronize, closed]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/codesee-arch-diagram.yml
+++ b/.github/workflows/codesee-arch-diagram.yml
@@ -1,12 +1,10 @@
+name: CodeSee Map
 on:
   push:
     branches:
       - master
   pull_request_target:
     types: [opened, synchronize, reopened]
-
-name: CodeSee Map
-
 jobs:
   test_map_action:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test-e2e-golang:
 	make -f $(DSLIM_EXAMPLES_DIR)/golang_centos/Makefile test-e2e
 	make -f $(DSLIM_EXAMPLES_DIR)/golang_gin_standard/Makefile test-e2e
 	make -f $(DSLIM_EXAMPLES_DIR)/golang_standard/Makefile test-e2e
-	true || make -f $(DSLIM_EXAMPLES_DIR)/golang_ubuntu/Makefile test-e2e  # TODO: Flaky one!
+	make -f $(DSLIM_EXAMPLES_DIR)/golang_ubuntu/Makefile test-e2e
 
 test-e2e-java:
 	make -f $(DSLIM_EXAMPLES_DIR)/java_corretto/Makefile test-e2e

--- a/pkg/app/master/inspectors/container/container_inspector.go
+++ b/pkg/app/master/inspectors/container/container_inspector.go
@@ -897,9 +897,12 @@ func (i *Inspector) RunContainer() error {
 			})
 	}
 
-	for idx := 0; idx < 3; idx++ {
+	// We really need this code block to produce conclusive
+	// outcomes. Hence, many retries to prevent (most of) the
+	// premature terminations of the master process with the
+	// sensor process (in a container) remaining (semi-)started.
+	for idx := 0; idx < 16; idx++ {
 		evt, err := i.ipcClient.GetEvent()
-
 		if err != nil {
 			if os.IsTimeout(err) || err == channel.ErrWaitTimeout {
 				if i.PrintState {
@@ -917,7 +920,7 @@ func (i *Inspector) RunContainer() error {
 		}
 
 		if evt == nil || evt.Name == "" {
-			i.logger.Debug("empty event waiting for the docker-slim container to start (trying again)...")
+			i.logger.Warn("empty event waiting for the docker-slim container to start (trying again)...")
 			continue
 		}
 


### PR DESCRIPTION
For ptrace(), it's normal not to find a traced process from time to
time. For instance, it could happen when the tracee is KILL-ed. If
such an event happens while the master process is still awaiting the
sensor's startup, it would cause the `docker-slim build` command to
fail with -124 exit code leaving the sensor in the (semi-)initialized
state (and not killing the container).

This commit prevents the sensor from sending any 'no such process'
events as errors back to the master. Instead, such events will be logged
on the sensor side.