### PR TITLE
Correct Make target on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,11 +895,11 @@ Pick one of the build options that works best for you.
 
 ##### Containerized
 
-Run `make` (or `./scripts/docker-builder.run.sh` or click on `./scripts/mac/docker-builder.run.command` on Macs) from the project directory (builds `docker-slim` in a Docker container; great if you don't want to install Go on your local machine and if you already have Docker).
+Run `make build_in_docker` on linux or `make build_m1_in_docker` on Macs (or `./scripts/docker-builder.run.sh` or click on `./scripts/mac/docker-builder.run.command` on Macs) from the project directory (builds `docker-slim` in a Docker container; great if you don't want to install Go on your local machine and if you already have Docker).
 
 ##### Native
 
-Run `make build` (or `./scripts/src.build.sh` or click on `./scripts/mac/src.build.command` on Macs) to build `docker-slim` natively (requires Go installed locally).
+Run `make build` on linux or `make build_m1` on Macs (or `./scripts/src.build.sh` or click on `./scripts/mac/src.build.command` on Macs) to build `docker-slim` natively (requires Go installed locally).
 
 Note:
 


### PR DESCRIPTION
[Fixes-347](https://github.com/docker-slim/docker-slim/issues/347)
==================================================================

The PR modifies the README and add make target for containerized and native build option in the instructions.
