### PR TITLE
GitHub Actions - Remove merged kubernetes-poc branch

### DIFF
--- a/.github/workflows/acceptance-testing-e2e.yml
+++ b/.github/workflows/acceptance-testing-e2e.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - iximiuz/kubernetes-support-poc
   pull_request:
     branches:
       - master


### PR DESCRIPTION
The branch with the Kubernetes runtime PoC has been merged. Hence, no need to trigger any pipelines for its head.
