### PR TITLE
Standalone Sensor Mode - Make creport.json file list complete

### DIFF
--- a/pkg/app/sensor/app.go
+++ b/pkg/app/sensor/app.go
@@ -29,6 +29,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	defaultArtifactDirName = "/opt/dockerslim/artifacts"
+)
+
 ///////////////////////////////////////////////////////////////////////////////
 
 func getCurrentPaths(root string) (map[string]interface{}, error) {
@@ -296,7 +300,14 @@ func runControlled(sensorCtx context.Context, dirName, mountPoint string) {
 
 				log.Info("sensor: waiting for monitor to finish...")
 
-				processReports(startCmd, mountPoint, monRes.peReport(), monRes.fanReport(), monRes.ptReport())
+				processReports(
+					defaultArtifactDirName,
+					startCmd,
+					mountPoint,
+					monRes.peReport(),
+					monRes.fanReport(),
+					monRes.ptReport(),
+				)
 
 				log.Info("sensor: monitor stopped...")
 				ipcServer.TryPublishEvt(&event.Message{Name: event.StopMonitorDone}, 3)
@@ -360,7 +371,14 @@ func runStandalone(
 
 	log.Info("sensor: target app is done.")
 
-	processReports(&startCmd, mountPoint, monRes.peReport(), monRes.fanReport(), ptReport)
+	processReports(
+		defaultArtifactDirName,
+		&startCmd,
+		mountPoint,
+		monRes.peReport(),
+		monRes.fanReport(),
+		ptReport,
+	)
 }
 
 func initSignalForwardingChannel(

--- a/pkg/app/sensor/artifacts.go
+++ b/pkg/app/sensor/artifacts.go
@@ -33,13 +33,12 @@ import (
 )
 
 const (
-	pidFileSuffix          = ".pid"
-	varRunDir              = "/var/run/"
-	fileTypeCmdName        = "file"
-	defaultArtifactDirName = "/opt/dockerslim/artifacts"
-	filesDirName           = "files"
-	filesArchiveName       = "files.tar"
-	preservedDirName       = "preserved"
+	pidFileSuffix    = ".pid"
+	varRunDir        = "/var/run/"
+	fileTypeCmdName  = "file"
+	filesDirName     = "files"
+	filesArchiveName = "files.tar"
+	preservedDirName = "preserved"
 )
 
 //TODO: extract these app, framework and language specific login into separate packages
@@ -222,6 +221,7 @@ func prepareEnv(storeLocation string, cmd *command.StartMonitor) {
 }
 
 func saveResults(
+	artifactDirName string,
 	cmd *command.StartMonitor,
 	fileNames map[string]*report.ArtifactProps,
 	fanMonReport *report.FanMonitorReport,
@@ -230,10 +230,10 @@ func saveResults(
 ) {
 	log.Debugf("saveResults(%v,...)", len(fileNames))
 
-	artifactDirName := defaultArtifactDirName
 	artifactStore := newArtifactStore(artifactDirName, fileNames, fanMonReport, ptMonReport, peReport, cmd)
 	artifactStore.prepareArtifacts()
 	artifactStore.saveArtifacts()
+	artifactStore.enumerateArtifacts()
 	//artifactStore.archiveArtifacts() //alternative way to xfer artifacts
 	artifactStore.saveReport()
 }
@@ -1425,8 +1425,8 @@ copyIncludes:
 		log.Debug("saveArtifacts: restoring preserved paths - %d", len(p.cmd.Preserves))
 
 		preservedDirPath := filepath.Join(p.storeLocation, preservedDirName)
-		filesDirPath := filepath.Join(p.storeLocation, filesDirName)
 		if fsutil.Exists(preservedDirPath) {
+			filesDirPath := filepath.Join(p.storeLocation, filesDirName)
 			preservePaths := preparePaths(getKeys(p.cmd.Preserves))
 			for inPath, isDir := range preservePaths {
 				srcPath := fmt.Sprintf("%s%s", preservedDirPath, inPath)
@@ -1637,9 +1637,76 @@ func (p *artifactStore) archiveArtifacts() {
 	errutil.FailOn(err)
 }
 
-func (p *artifactStore) saveReport() {
-	sort.Strings(p.nameList)
+// Go over all saved artifacts and update the name list to make
+// sure all the files & folders are reflected in the final report.
+// Hopefully, just a temporary workaround until a proper refactoring.
+func (p *artifactStore) enumerateArtifacts() {
+	knownFiles := list2map(p.nameList)
+	artifactFilesDir := filepath.Join(p.storeLocation, filesDirName)
 
+	var curpath string
+	dirqueue := []string{artifactFilesDir}
+	for len(dirqueue) > 0 {
+		curpath, dirqueue = dirqueue[0], dirqueue[1:]
+
+		entries, err := os.ReadDir(curpath)
+		if err != nil {
+			log.WithError(err).Warn("artifactStore.enumerateArtifacts: readdir error")
+			// Keep processing though since it might have been a partial result.
+		}
+
+		// Leaf element - empty dir.
+		if len(entries) == 0 {
+			// Trim /opt/dockerslim/artifacts/files prefix from the dirpath.
+			curpath = strings.TrimPrefix(curpath, artifactFilesDir)
+
+			if knownFiles[curpath] {
+				continue
+			}
+
+			if props, err := artifactProps(curpath); err == nil {
+				p.nameList = append(p.nameList, curpath)
+				p.rawNames[curpath] = props
+				knownFiles[curpath] = true
+			} else {
+				log.
+					WithError(err).
+					WithField("path", curpath).
+					Warn("artifactStore.enumerateArtifacts: failed computing dir artifact props")
+			}
+			continue
+		}
+
+		for _, child := range entries {
+			childpath := filepath.Join(curpath, child.Name())
+			if child.IsDir() {
+				dirqueue = append(dirqueue, childpath)
+				continue
+			}
+
+			// Trim /opt/dockerslim/artifacts/files prefix from the filepath.
+			childpath = strings.TrimPrefix(childpath, artifactFilesDir)
+
+			// Leaf element - regular file or symlink.
+			if knownFiles[childpath] {
+				continue
+			}
+
+			if props, err := artifactProps(childpath); err == nil {
+				p.nameList = append(p.nameList, childpath)
+				p.rawNames[childpath] = props
+				knownFiles[childpath] = true
+			} else {
+				log.
+					WithError(err).
+					WithField("paht", childpath).
+					Warn("artifactStore.enumerateArtifacts: failed computing artifact props")
+			}
+		}
+	}
+}
+
+func (p *artifactStore) saveReport() {
 	creport := report.ContainerReport{
 		Monitors: report.MonitorReports{
 			Pt:  p.ptMonReport,
@@ -1658,6 +1725,7 @@ func (p *artifactStore) saveReport() {
 		},
 	}
 
+	sort.Strings(p.nameList)
 	for _, fname := range p.nameList {
 		creport.Image.Files = append(creport.Image.Files, p.rawNames[fname])
 	}
@@ -2177,4 +2245,38 @@ func shellDependencies() ([]string, error) {
 	}
 
 	return allDeps, nil
+}
+
+// TODO: Merge it with prepareArtifact().
+func artifactProps(filename string) (*report.ArtifactProps, error) {
+	fileInfo, err := os.Lstat(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	fileType := report.UnknownArtifactType
+	switch true {
+	case fileInfo.Mode().IsRegular():
+		fileType = report.FileArtifactType
+	case (fileInfo.Mode() & os.ModeSymlink) != 0:
+		fileType = report.SymlinkArtifactType
+	case fileInfo.IsDir():
+		fileType = report.DirArtifactType
+	}
+
+	return &report.ArtifactProps{
+		FileType: fileType,
+		FilePath: filename,
+		Mode:     fileInfo.Mode(),
+		ModeText: fileInfo.Mode().String(),
+		FileSize: fileInfo.Size(),
+	}, nil
+}
+
+func list2map(l []string) map[string]bool {
+	m := map[string]bool{}
+	for _, v := range l {
+		m[v] = true
+	}
+	return m
 }

--- a/pkg/app/sensor/data_processor.go
+++ b/pkg/app/sensor/data_processor.go
@@ -18,6 +18,7 @@ import (
 )
 
 func processReports(
+	artifactDirName string,
 	cmd *command.StartMonitor,
 	mountPoint string,
 	peReport *report.PeMonitorReport,
@@ -41,7 +42,7 @@ func processReports(
 
 	log.Debugf("processReports(): len(fanReport.ProcessFiles)=%v / fileCount=%v", len(fanReport.ProcessFiles), fileCount)
 	allFilesMap := findSymlinks(fileList, mountPoint)
-	saveResults(cmd, allFilesMap, fanReport, ptReport, peReport)
+	saveResults(artifactDirName, cmd, allFilesMap, fanReport, ptReport, peReport)
 }
 
 func getProcessChildren(pid int, targetPidList map[int]bool, processChildrenMap map[int][]int) {

--- a/pkg/report/container_report.go
+++ b/pkg/report/container_report.go
@@ -11,10 +11,10 @@ type ArtifactType int
 
 // Artifact type ID constants
 const (
-	DirArtifactType     = 1
-	FileArtifactType    = 2
-	SymlinkArtifactType = 3
-	UnknownArtifactType = 99
+	DirArtifactType     ArtifactType = 1
+	FileArtifactType    ArtifactType = 2
+	SymlinkArtifactType ArtifactType = 3
+	UnknownArtifactType ArtifactType = 99
 )
 
 // DefaultContainerReportFileName is the default container report file name


### PR DESCRIPTION
While a proper solution is still required, at the moment it's done by re-enumerating the artifacts/files folder right before generating the creport file.