### PR TITLE
refactor: Sensor start command to support CMD + ENTRYPOINT

### DIFF
--- a/pkg/ipc/command/command.go
+++ b/pkg/ipc/command/command.go
@@ -41,9 +41,10 @@ type Message interface {
 // StartMonitor contains the start monitor command fields
 type StartMonitor struct {
 	RTASourcePT                  bool                          `json:"rta_source_ptrace"`
-	Entrypoint                   []string                      `json:"entrypoint,omitempty"`
 	AppName                      string                        `json:"app_name"`
 	AppArgs                      []string                      `json:"app_args,omitempty"`
+	AppEntrypoint                []string                      `json:"app_entrypoint,omitempty"`
+	AppCmd                       []string                      `json:"app_cmd,omitempty"`
 	AppUser                      string                        `json:"app_user,omitempty"`
 	RunTargetAsUser              bool                          `json:"run_tas_user,omitempty"`
 	KeepPerms                    bool                          `json:"keep_perms,omitempty"`


### PR DESCRIPTION
With the addition of the standalone mode, we'll need to support the Docker's original CMD + ENTRYPOINT mode alongside the "legacy" app_name + app_args.
