### PR TITLE
fix: set container after modification

### DIFF
--- a/pkg/app/master/inspectors/pod/pod_inspector.go
+++ b/pkg/app/master/inspectors/pod/pod_inspector.go
@@ -365,6 +365,7 @@ func (i *Inspector) prepareWorkload() error {
 		targetCont.SecurityContext.Capabilities.Add,
 		"SYS_ADMIN",
 	)
+	i.workload.SetContainer(targetCont)
 
 	return nil
 }

--- a/pkg/app/master/kubernetes/workload.go
+++ b/pkg/app/master/kubernetes/workload.go
@@ -87,6 +87,15 @@ func (w *Workload) DefaultContainer() *corev1.Container {
 	return nil
 }
 
+func (w *Workload) SetContainer(ctr *corev1.Container) {
+	containers := w.Template().Spec.Containers
+	for i, c := range containers {
+		if c.Name == ctr.Name {
+			containers[i] = *ctr
+		}
+	}
+}
+
 func (w *Workload) TargetContainer() *corev1.Container {
 	if w.targetContainerName == "" {
 		return w.DefaultContainer()


### PR DESCRIPTION
Signed-off-by: fengxsong <fengxsong@outlook.com>

Should set container after modification, otherwise it won't be affected.


