### PR TITLE
fix: fanotify monitor missing event draining

### DIFF
--- a/pkg/app/sensor/artifacts/artifacts.go
+++ b/pkg/app/sensor/artifacts/artifacts.go
@@ -217,7 +217,7 @@ func (a *artifactor) GetCurrentPaths(root string, excludes []string) (map[string
 
 			// Optimization: Exclude folders early on to prevent slow enumerat
 			//               Can help with mounting big folders from the host.
-			// TODO: Combine this logic with the similar logic in artifacts.go
+			// TODO: Combine this logic with the similar logic in findSymlinks().
 			for _, xpattern := range excludes {
 				if match, _ := doublestar.Match(xpattern, pth); match {
 					if info.Mode().IsDir() {
@@ -2480,15 +2480,6 @@ func findSymlinks(files []string, mountPoint string, excludes []string) map[stri
 		symlinks[symlinkFileName] = linkRef
 	}
 
-	//getting the root device is a leftover from the legacy code (not really necessary anymore)
-	devID, err := getFileDevice(mountPoint)
-	if err != nil {
-		log.Debugf("findSymlinks - no device ID (%v)", err)
-		return result
-	}
-
-	log.Debugf("findSymlinks - deviceId=%v", devID)
-
 	inodes, devices := filesToInodesNative(files)
 	log.Debugf("findSymlinks - len(inodes)=%v len(devices)=%v", len(inodes), len(devices))
 
@@ -2516,7 +2507,7 @@ func findSymlinks(files []string, mountPoint string, excludes []string) map[stri
 			// Optimization: Avoid walking excluded folders. Supposed to help with
 			//               mounting big folders from the host (they should be explicitly
 			//               excluded).
-			// TODO: Combine this logic with the similar logic in artifacts.go
+			// TODO: Combine this logic with the similar logic in GetCurrentPaths().
 			for _, xpattern := range excludes {
 				if match, _ := doublestar.Match(xpattern, fullName); match {
 					if fileInfo.Mode().IsDir() {

--- a/pkg/app/sensor/monitors/composite_test.go
+++ b/pkg/app/sensor/monitors/composite_test.go
@@ -34,7 +34,7 @@ func TestCompositeMonitor_Lifecycle(t *testing.T) {
 	select {
 	case <-mon.Done():
 		break
-	case <-time.After(1 * time.Second):
+	case <-time.After(1*time.Second + minPassiveMonitoring):
 		t.Fatal("composite monitor must be done by this time")
 	}
 

--- a/test/e2e-tests.mk
+++ b/test/e2e-tests.mk
@@ -5,7 +5,7 @@ GO_TEST_FLAGS =  # E.g.: make test-e2e-sensor GO_TEST_FLAGS='-run TestXyz'
 
 # run sensor only e2e tests
 test-e2e-sensor:
-	go test -v -tags e2e -count 10 $(GO_TEST_FLAGS) $(CURDIR)/pkg/app/sensor
+	go test -v -tags e2e -count 20 -timeout 30m $(GO_TEST_FLAGS) $(CURDIR)/pkg/app/sensor
 
 # run all e2e tests at once
 .PHONY:


### PR DESCRIPTION
This is a fix for #406 that was misclassified as a symlink-related issue. The actual root cause of the bug was the fanotify monitor missing all/many fs events due to the missing event channel draining.