### PR TITLE
feat: Sensor duplicates target app stdout/stderr to files

### DIFF
--- a/pkg/app/sensor/app.go
+++ b/pkg/app/sensor/app.go
@@ -52,13 +52,16 @@ const (
 	lifecycleHookCommandFlagUsage   = "(optional) path to an executable that'll be invoked at various sensor lifecycle events (post-start, pre-shutdown, etc)"
 	lifecycleHookCommandFlagDefault = ""
 
+	// Should stopSignal and stopGracePeriod become StartMonitor
+	// command's fields instead? Hypothetically, in a multi-command
+	// monitoring run, these two params may have different values.
 	stopSignalFlagUsage   = "signal to stop the target app and start producing the report"
 	stopSignalFlagDefault = "TERM"
 
 	stopGracePeriodFlagUsage   = "time to wait for the graceful termination of the target app (before sensor will send it SIGKILL)"
 	stopGracePeriodFlagDefault = 5 * time.Second
 
-	// Soon to become flags?
+	// Soon to become a flag?
 	defaultEventsFilePath = app.DefaultArtifactDirPath + "/events.json"
 )
 

--- a/pkg/app/sensor/monitors/ptrace/monitor.go
+++ b/pkg/app/sensor/monitors/ptrace/monitor.go
@@ -94,7 +94,7 @@ func (m *monitor) Start() error {
 	if appState == ptrace.AppFailed {
 		// Don't need to wait for the 'done' state.
 		log.Error("ptmon: pta state watcher - target app failed")
-		return errors.SE("sensor.ptrace.Run/ptrace.Run", "call.error", err)
+		return fmt.Errorf("ptmon: target app startup failed: %q", appState)
 	}
 	if appState != ptrace.AppStarted {
 		// Cannot really happen.

--- a/pkg/app/sensor/monitors/ptrace/monitor_arm64.go
+++ b/pkg/app/sensor/monitors/ptrace/monitor_arm64.go
@@ -130,7 +130,16 @@ func (m *monitor) Start() error {
 			runtime.LockOSThread()
 
 			var err error
-			app, err = launcher.Start(appName, appArgs, workDir, appUser, runTargetAsUser, rtaSourcePT)
+			app, err = launcher.Start(
+				appName,
+				appArgs,
+				workDir,
+				appUser,
+				runTargetAsUser,
+				rtaSourcePT,
+				m.runOpt.AppStdout,
+				m.runOpt.AppStderr,
+			)
 			if err != nil {
 				m.status.err = errors.SE("sensor.ptrace.Run/launcher.Start", "call.error", err)
 				close(m.doneCh)

--- a/pkg/ipc/command/command.go
+++ b/pkg/ipc/command/command.go
@@ -46,6 +46,8 @@ type StartMonitor struct {
 	AppEntrypoint                []string                      `json:"app_entrypoint,omitempty"`
 	AppCmd                       []string                      `json:"app_cmd,omitempty"`
 	AppUser                      string                        `json:"app_user,omitempty"`
+	AppStdoutToFile              bool                          `json:"app_stdout_to_file"`
+	AppStderrToFile              bool                          `json:"app_stderr_to_file"`
 	RunTargetAsUser              bool                          `json:"run_tas_user,omitempty"`
 	ReportOnMainPidExit          bool                          `json:"report_on_main_pid_exit"`
 	KeepPerms                    bool                          `json:"keep_perms,omitempty"`

--- a/pkg/launcher/launcher.go
+++ b/pkg/launcher/launcher.go
@@ -4,6 +4,7 @@
 package launcher
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -75,7 +76,16 @@ func fixStdioPermissionsAlt(uid int) error {
 }
 
 // Start starts the target application in the container
-func Start(appName string, appArgs []string, appDir, appUser string, runTargetAsUser, doPtrace bool) (*exec.Cmd, error) {
+func Start(
+	appName string,
+	appArgs []string,
+	appDir string,
+	appUser string,
+	runTargetAsUser bool,
+	doPtrace bool,
+	appStdout io.Writer,
+	appStderr io.Writer,
+) (*exec.Cmd, error) {
 	log.Debugf("launcher.Start(%v,%v,%v,%v)", appName, appArgs, appDir, appUser)
 	if !runTargetAsUser {
 		appUser = ""
@@ -126,9 +136,9 @@ func Start(appName string, appArgs []string, appDir, appUser string, runTargetAs
 	}
 
 	app.Dir = appDir
-	app.Stdout = os.Stdout
-	app.Stderr = os.Stderr
 	app.Stdin = os.Stdin
+	app.Stdout = appStdout
+	app.Stderr = appStderr
 
 	err := app.Start()
 	if err != nil {

--- a/pkg/monitor/ptrace/ptrace.go
+++ b/pkg/monitor/ptrace/ptrace.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -115,6 +116,9 @@ type App struct {
 	User      string
 	RunAsUser bool
 
+	appStdout io.Writer
+	appStderr io.Writer
+
 	RTASourcePT         bool
 	reportOnMainPidExit bool
 
@@ -176,6 +180,9 @@ func newApp(
 		WorkDir:   runOpt.WorkDir,
 		User:      runOpt.User,
 		RunAsUser: runOpt.RunAsUser,
+
+		appStdout: runOpt.AppStdout,
+		appStderr: runOpt.AppStderr,
 
 		RTASourcePT:         runOpt.RTASourcePT,
 		reportOnMainPidExit: runOpt.ReportOnMainPidExit,
@@ -404,7 +411,16 @@ func (app *App) FileActivity() map[string]*report.FSActivityInfo {
 func (app *App) start() error {
 	log.Debug("ptrace.App.start")
 	var err error
-	app.cmd, err = launcher.Start(app.Cmd, app.Args, app.WorkDir, app.User, app.RunAsUser, app.RTASourcePT)
+	app.cmd, err = launcher.Start(
+		app.Cmd,
+		app.Args,
+		app.WorkDir,
+		app.User,
+		app.RunAsUser,
+		app.RTASourcePT,
+		app.appStdout,
+		app.appStderr,
+	)
 	if err != nil {
 		log.WithError(err).Errorf(
 			"ptrace.App.start: cmd='%v' args='%+v' dir='%v'",

--- a/pkg/monitor/ptrace/types.go
+++ b/pkg/monitor/ptrace/types.go
@@ -1,8 +1,14 @@
 package ptrace
 
+import (
+	"io"
+)
+
 type AppRunOpt struct {
 	Cmd                 string
 	Args                []string
+	AppStdout           io.Writer
+	AppStderr           io.Writer
 	WorkDir             string
 	User                string
 	RunAsUser           bool

--- a/pkg/test/e2e/sensor/monitor.go
+++ b/pkg/test/e2e/sensor/monitor.go
@@ -27,6 +27,18 @@ func WithAppNameArgs(name string, arg ...string) startMonitorOpt {
 	}
 }
 
+func WithAppStdoutToFile() startMonitorOpt {
+	return func(cmd *command.StartMonitor) {
+		cmd.AppStdoutToFile = true
+	}
+}
+
+func WithAppStderrToFile() startMonitorOpt {
+	return func(cmd *command.StartMonitor) {
+		cmd.AppStderrToFile = true
+	}
+}
+
 func WithPreserves(path ...string) startMonitorOpt {
 	return func(cmd *command.StartMonitor) {
 		cmd.Preserves = commands.ParsePaths(path)


### PR DESCRIPTION
Subj. The only thing that might be worth mentioning separately is the os.Pipe() + io.Copy() trick to make the os/exec.Cmd.Wait() not hanging (unlike a simple io.MultiWriter(os.Stdout, os.OpenFile()) trick).