### PR TITLE
sensor: Fix up target app HOME env var when run as user

### DIFF
--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -22,31 +22,31 @@ type DistroInfo struct {
 	DisplayName string `json:"display_name"`
 }
 
-func ResolveUser(identity string) (uint32, uint32, error) {
+func ResolveUser(identity string) (uid uint32, gid uint32, home string, err error) {
 	var userInfo *user.User
 	if _, err := strconv.ParseUint(identity, 10, 32); err == nil {
 		userInfo, err = user.LookupId(identity)
 		if err != nil {
-			return 0, 0, err
+			return 0, 0, "", err
 		}
 	} else {
 		userInfo, err = user.Lookup(identity)
 		if err != nil {
-			return 0, 0, err
+			return 0, 0, "", err
 		}
 	}
 
-	uid, err := strconv.ParseUint(userInfo.Uid, 10, 32)
+	uid64, err := strconv.ParseUint(userInfo.Uid, 10, 32)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, "", err
 	}
 
-	gid, err := strconv.ParseUint(userInfo.Gid, 10, 32)
+	gid64, err := strconv.ParseUint(userInfo.Gid, 10, 32)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, "", err
 	}
 
-	return uint32(uid), uint32(gid), nil
+	return uint32(uid64), uint32(gid64), userInfo.HomeDir, nil
 }
 
 func ResolveGroup(identity string) (uint32, error) {

--- a/pkg/test/e2e/sensor/monitor.go
+++ b/pkg/test/e2e/sensor/monitor.go
@@ -5,9 +5,9 @@ import (
 	"github.com/docker-slim/docker-slim/pkg/ipc/command"
 )
 
-type startMonitorOpt func(*command.StartMonitor)
+type StartMonitorOpt func(*command.StartMonitor)
 
-func WithSaneDefaults() startMonitorOpt {
+func WithSaneDefaults() StartMonitorOpt {
 	return func(cmd *command.StartMonitor) {
 		cmd.RTASourcePT = true
 		cmd.KeepPerms = true
@@ -20,39 +20,39 @@ func WithSaneDefaults() startMonitorOpt {
 	}
 }
 
-func WithAppNameArgs(name string, arg ...string) startMonitorOpt {
+func WithAppNameArgs(name string, arg ...string) StartMonitorOpt {
 	return func(cmd *command.StartMonitor) {
 		cmd.AppName = name
 		cmd.AppArgs = arg
 	}
 }
 
-func WithAppUser(user string) startMonitorOpt {
+func WithAppUser(user string) StartMonitorOpt {
 	return func(cmd *command.StartMonitor) {
 		cmd.AppUser = user
 		cmd.RunTargetAsUser = true
 	}
 }
 
-func WithAppStdoutToFile() startMonitorOpt {
+func WithAppStdoutToFile() StartMonitorOpt {
 	return func(cmd *command.StartMonitor) {
 		cmd.AppStdoutToFile = true
 	}
 }
 
-func WithAppStderrToFile() startMonitorOpt {
+func WithAppStderrToFile() StartMonitorOpt {
 	return func(cmd *command.StartMonitor) {
 		cmd.AppStderrToFile = true
 	}
 }
 
-func WithPreserves(path ...string) startMonitorOpt {
+func WithPreserves(path ...string) StartMonitorOpt {
 	return func(cmd *command.StartMonitor) {
 		cmd.Preserves = commands.ParsePaths(path)
 	}
 }
 
-func NewMonitorStartCommand(opts ...startMonitorOpt) command.StartMonitor {
+func NewMonitorStartCommand(opts ...StartMonitorOpt) command.StartMonitor {
 	cmd := command.StartMonitor{}
 
 	for _, opt := range opts {

--- a/test/e2e-tests.mk
+++ b/test/e2e-tests.mk
@@ -5,7 +5,7 @@ GO_TEST_FLAGS =  # E.g.: make test-e2e-sensor GO_TEST_FLAGS='-run TestXyz'
 
 # run sensor only e2e tests
 test-e2e-sensor:
-	go test -v -tags e2e -count 20 -timeout 30m $(GO_TEST_FLAGS) $(CURDIR)/pkg/app/sensor
+	go test -v -tags e2e -count 10 -timeout 30m $(GO_TEST_FLAGS) $(CURDIR)/pkg/app/sensor
 
 # run all e2e tests at once
 .PHONY:


### PR DESCRIPTION
Sensor typically needs to run as root while the target app may need to use a less privileged user. By default, conainer runtimes (like Docker) set the HOME env var upon container startup based on the container's user and the corresponding record in the /etc/passwd file in the image (if any, "/" otherwser). However, instrumented container's user is often different from the target app's user. Thus, sensor needs extra logic to restore the right HOME var doing similar computations.

NB: Having HOME env var set is mandatory in accordance with POSIX.