### PR TITLE
sensor: Extra test for HOME env var propagation

### DIFF
--- a/pkg/app/sensor/app_test.go
+++ b/pkg/app/sensor/app_test.go
@@ -397,6 +397,10 @@ func TestTargetAppEnvVars(t *testing.T) {
 		user  string
 		home  string
 	}{
+		// nixery.dev/shell lacks the /etc/passwd file: all UIDs should end up with HOME=/
+		{image: "nixery.dev/shell", user: "0", home: "/"},
+		{image: "nixery.dev/shell", user: "65534", home: "/"},
+
 		// Alpine
 		{image: imageSimpleCLI, home: "/root"},
 		{image: imageSimpleCLI, user: "root", home: "/root"},

--- a/pkg/test/e2e/sensor/sensor.go
+++ b/pkg/test/e2e/sensor/sensor.go
@@ -138,7 +138,7 @@ func (s *Sensor) StartControlled(ctx context.Context) error {
 		[]string{
 			"--name", s.contName,
 			"--cap-add", "ALL",
-			"--user", "root",
+			"--user", "0",
 			"--volume", s.sensorExePath + ":/opt/dockerslim/sensor",
 			"--publish", fmt.Sprintf("%d", channel.CmdPort),
 			"--publish", fmt.Sprintf("%d", channel.EvtPort),
@@ -225,7 +225,7 @@ func (s *Sensor) StartStandalone(
 		[]string{
 			"--name", s.contName,
 			"--cap-add", "ALL",
-			"--user", "root",
+			"--user", "0",
 			"--volume", s.sensorExePath + ":/opt/dockerslim/sensor",
 			"--volume", commandFilePath + ":/opt/dockerslim/commands.json",
 			"--entrypoint", "/opt/dockerslim/sensor",


### PR DESCRIPTION
Covers images w/o `/etc/passwd` file.