### PR TITLE
sensor: Archive "run" artifacts before exiting

### DIFF
--- a/pkg/app/sensor/controlled/controlled_test.go
+++ b/pkg/app/sensor/controlled/controlled_test.go
@@ -62,6 +62,10 @@ func (a *artifactorStub) PrepareEnv(cmd *command.StartMonitor) error {
 	return nil
 }
 
+func (a *artifactorStub) Archive() error {
+	return nil
+}
+
 func (a *artifactorStub) ProcessReports(
 	cmd *command.StartMonitor,
 	mountPoint string,

--- a/pkg/test/e2e/sensor/sensor.go
+++ b/pkg/test/e2e/sensor/sensor.go
@@ -1,10 +1,13 @@
 package sensor
 
 import (
+	"archive/tar"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,11 +33,12 @@ const (
 	// of the paths on the sensor side won't be unnoticed.
 	artifactDirName   = "artifacts"
 	artifactDirPath   = "/opt/dockerslim/" + artifactDirName
-	commandFileName   = "commands.json"
-	sensorLogFileName = "sensor.log"
-	appStdoutFileName = "app_stdout.log"
-	appStderrFileName = "app_stderr.log"
-	eventFileName     = "events.json"
+	CommandsFileName  = "commands.json"
+	SensorLogFileName = "sensor.log"
+	AppStdoutFileName = "app_stdout.log"
+	AppStderrFileName = "app_stderr.log"
+	EventsFileName    = "events.json"
+	runArchiveName    = "run.tar"
 )
 
 var (
@@ -55,23 +59,41 @@ func WithLifecycleHook(cmd string) sensorOpt {
 	}
 }
 
+func WithCapabilities(caps ...string) sensorOpt {
+	return func(s *Sensor) {
+		s.capAdd = caps
+	}
+}
+
+func WithoutCapabilities(caps ...string) sensorOpt {
+	return func(s *Sensor) {
+		s.capDrop = caps
+	}
+}
+
 type Sensor struct {
 	image          dockerapi.Image
 	contName       string
 	sensorExePath  string
 	contextDirPath string
 
+	// "Opts"
 	useLogFile    bool
 	lifecycleHook string
+	capAdd        []string
+	capDrop       []string
+	user          string
 
 	// "Nullable"
-	contID  string
-	client  *ipc.Client
-	stopped bool
+	contID      string
+	rawCommands string
+	client      *ipc.Client
+	stopped     bool
 
 	// "Artifacts"
-	creport   *report.ContainerReport
-	rawEvents string
+	creport    *report.ContainerReport
+	rawCReport string
+	rawEvents  string
 }
 
 func NewSensor(
@@ -106,6 +128,8 @@ func NewSensor(
 		contName:       strings.ToLower(contName),
 		sensorExePath:  sensorExePath,
 		contextDirPath: contextDirPath,
+		capAdd:         []string{"ALL"},
+		user:           "0",
 	}
 
 	for _, opt := range opts {
@@ -135,15 +159,17 @@ func (s *Sensor) StartControlled(ctx context.Context) error {
 
 	contID, err := containerCreate(
 		ctx,
-		[]string{
-			"--name", s.contName,
-			"--cap-add", "ALL",
-			"--user", "0",
-			"--volume", s.sensorExePath + ":/opt/dockerslim/sensor",
-			"--publish", fmt.Sprintf("%d", channel.CmdPort),
-			"--publish", fmt.Sprintf("%d", channel.EvtPort),
-			"--entrypoint", "/opt/dockerslim/sensor",
-		},
+		flatten(
+			s.capabilities(),
+			[]string{
+				"--name", s.contName,
+				"--user", s.user,
+				"--volume", s.sensorExePath + ":/opt/dockerslim/sensor",
+				"--publish", fmt.Sprintf("%d", channel.CmdPort),
+				"--publish", fmt.Sprintf("%d", channel.EvtPort),
+				"--entrypoint", "/opt/dockerslim/sensor",
+			},
+		),
 		s.image.ID,
 		s.commonStartFlags()...,
 	)
@@ -204,10 +230,16 @@ func (s *Sensor) StartStandalone(
 		WithField("command", fmt.Sprintf("%+v", cmd)).
 		Debug("Starting test sensor (standalone mode)...")
 
-	commandFilePath := filepath.Join(s.contextDirPath, commandFileName)
-	if err := jsonDump(commandFilePath, cmd); err != nil {
-		return fmt.Errorf("cannot create %s file: %w", commandFileName, err)
+	commandsFilePath := filepath.Join(s.contextDirPath, CommandsFileName)
+	if err := jsonDump(commandsFilePath, cmd); err != nil {
+		return fmt.Errorf("cannot create %s file: %w", CommandsFileName, err)
 	}
+
+	rawCommands, err := ioutil.ReadFile(commandsFilePath)
+	if err != nil {
+		return fmt.Errorf("cannot re-read %s file: %w", CommandsFileName, err)
+	}
+	s.rawCommands = string(rawCommands)
 
 	stopSignal := "SIGTERM"
 	if len(s.image.Config.StopSignal) > 0 {
@@ -222,14 +254,16 @@ func (s *Sensor) StartStandalone(
 
 	contID, err := containerCreate(
 		ctx,
-		[]string{
-			"--name", s.contName,
-			"--cap-add", "ALL",
-			"--user", "0",
-			"--volume", s.sensorExePath + ":/opt/dockerslim/sensor",
-			"--volume", commandFilePath + ":/opt/dockerslim/commands.json",
-			"--entrypoint", "/opt/dockerslim/sensor",
-		},
+		flatten(
+			s.capabilities(),
+			[]string{
+				"--name", s.contName,
+				"--user", s.user,
+				"--volume", s.sensorExePath + ":/opt/dockerslim/sensor",
+				"--volume", commandsFilePath + ":/opt/dockerslim/commands.json",
+				"--entrypoint", "/opt/dockerslim/sensor",
+			},
+		),
 		s.image.ID,
 		flatten(
 			s.commonStartFlags(),
@@ -382,20 +416,22 @@ func (s *Sensor) DownloadArtifacts(ctx context.Context) error {
 		return fmt.Errorf("cannot download test sensor's artifacts: %w", err)
 	}
 
-	var creport report.ContainerReport
-	if err := fsutil.LoadStructFromFile(
-		filepath.Join(localArtifactPath, report.DefaultContainerReportFileName),
-		&creport,
-	); err != nil {
-		return fmt.Errorf("cannot load test sensor's report: %w", err)
+	creportFilePath := filepath.Join(localArtifactPath, report.DefaultContainerReportFileName)
+	rawCReport, err := ioutil.ReadFile(creportFilePath)
+	if err == nil {
+		s.rawCReport = string(rawCReport)
+
+		var creport report.ContainerReport
+		if err := fsutil.LoadStructFromFile(creportFilePath, &creport); err != nil {
+			return fmt.Errorf("cannot decode test sensor's report: %w", err)
+		}
+		s.creport = &creport
 	}
 
-	s.creport = &creport
-
 	if s.client == nil {
-		rawEvents, err := os.ReadFile(filepath.Join(s.contextDirPath, artifactDirName, eventFileName))
+		rawEvents, err := os.ReadFile(filepath.Join(s.contextDirPath, artifactDirName, EventsFileName))
 		if err != nil {
-			return fmt.Errorf("cannot read %s file: %w", eventFileName, err)
+			return fmt.Errorf("cannot read %s file: %w", EventsFileName, err)
 		}
 		s.rawEvents = string(rawEvents)
 	}
@@ -435,7 +471,7 @@ func (s *Sensor) ContainerLogs(ctx context.Context) (string, error) {
 func (s *Sensor) ContainerLogsOrFail(t *testing.T, ctx context.Context) string {
 	logs, err := s.ContainerLogs(ctx)
 	if err != nil {
-		t.Fatal("Cannot retrieve target container logs", err)
+		t.Fatal("Cannot retrieve target container logs:", err)
 	}
 	return logs
 }
@@ -443,7 +479,7 @@ func (s *Sensor) ContainerLogsOrFail(t *testing.T, ctx context.Context) string {
 func (s *Sensor) SensorLogs(ctx context.Context) (string, error) {
 	if s.useLogFile {
 		bytes, err := os.ReadFile(
-			filepath.Join(s.contextDirPath, artifactDirName, sensorLogFileName),
+			filepath.Join(s.contextDirPath, artifactDirName, SensorLogFileName),
 		)
 		return string(bytes), err
 	}
@@ -453,7 +489,7 @@ func (s *Sensor) SensorLogs(ctx context.Context) (string, error) {
 func (s *Sensor) SensorLogsOrFail(t *testing.T, ctx context.Context) string {
 	logs, err := s.SensorLogs(ctx)
 	if err != nil {
-		t.Fatal("Cannot retrieve sensor logs", err)
+		t.Fatal("Cannot retrieve sensor logs:", err)
 	}
 	return logs
 }
@@ -482,6 +518,16 @@ func (s *Sensor) PrintState(ctx context.Context) {
 		fmt.Fprintln(os.Stderr, "-=== events.json ===-")
 		fmt.Fprintln(os.Stderr, s.rawEvents)
 		fmt.Fprintln(os.Stderr, "-=== eof: events.json ===-")
+	}
+
+	if len(s.contID) > 0 && s.useLogFile {
+		fmt.Fprintln(os.Stderr, "-=== Sensor logs ===-")
+		if sensorLogs, err := s.SensorLogs(ctx); err == nil {
+			fmt.Fprintln(os.Stderr, sensorLogs)
+		} else {
+			log.WithError(err).Error("Cannot obtain sensor logs")
+		}
+		fmt.Fprintln(os.Stderr, "-=== eof: Sensor logs ===-")
 	}
 
 	if len(s.contID) > 0 {
@@ -548,11 +594,11 @@ func (s *Sensor) AssertTargetAppLogsEqualTo(t *testing.T, ctx context.Context, w
 }
 
 func (s *Sensor) AssertTargetAppStdoutFileEqualsTo(t *testing.T, ctx context.Context, expected string) {
-	s.assertTargetAppStdFileEqualsTo(t, ctx, appStdoutFileName, expected)
+	s.assertTargetAppStdFileEqualsTo(t, ctx, AppStdoutFileName, expected)
 }
 
 func (s *Sensor) AssertTargetAppStderrFileEqualsTo(t *testing.T, ctx context.Context, expected string) {
-	s.assertTargetAppStdFileEqualsTo(t, ctx, appStderrFileName, expected)
+	s.assertTargetAppStdFileEqualsTo(t, ctx, AppStderrFileName, expected)
 }
 
 func (s *Sensor) assertTargetAppStdFileEqualsTo(
@@ -577,7 +623,7 @@ func (s *Sensor) assertTargetAppStdFileEqualsTo(
 }
 
 // Checks the presense of the expected events AND the occurrence order.
-func (s *Sensor) AssertSensorEventFileContains(
+func (s *Sensor) AssertSensorEventsFileContains(
 	t *testing.T,
 	ctx context.Context,
 	expected ...event.Type,
@@ -627,15 +673,74 @@ func (s *Sensor) AssertReportNotIncludesFiles(t *testing.T, filepath ...string) 
 	}
 }
 
+func (s *Sensor) AssertArtifactsArchiveContains(
+	t *testing.T,
+	ctx context.Context,
+	filename ...string,
+) {
+	archiveFilePath := filepath.Join(s.contextDirPath, artifactDirName, runArchiveName)
+	archiveFile, err := os.Open(archiveFilePath)
+	if err != nil {
+		t.Errorf("Cannot open report archive %q: %v", archiveFilePath, err)
+		return
+	}
+	defer archiveFile.Close()
+
+	found := map[string]bool{}
+	for _, f := range filename {
+		found[f] = false
+	}
+
+	reader := tar.NewReader(archiveFile)
+	for {
+		header, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Errorf("Failed reading tar archive header: %v", err)
+			continue
+		}
+
+		if _, expected := found[header.Name]; !expected {
+			continue
+		}
+
+		_, err = ioutil.ReadAll(reader)
+		if err != nil {
+			t.Errorf("Failed reading expected tar archive entry %q: %v", header.Name, err)
+			continue
+		}
+
+		found[header.Name] = true
+	}
+
+	for name := range found {
+		if !found[name] {
+			t.Errorf("Artifacts archive doesn't contain entry %q", name)
+		}
+	}
+}
+
 func (s *Sensor) commonStartFlags() []string {
 	flags := []string{"-l", "debug", "-d"}
 	if s.useLogFile {
-		flags = append(flags, "-o", filepath.Join(artifactDirPath, sensorLogFileName))
+		flags = append(flags, "-o", filepath.Join(artifactDirPath, SensorLogFileName))
 	}
 	if len(s.lifecycleHook) > 0 {
 		flags = append(flags, "-a", s.lifecycleHook)
 	}
 	return flags
+}
+
+func (s *Sensor) capabilities() (caps []string) {
+	for _, c := range s.capAdd {
+		caps = append(caps, "--cap-add="+c)
+	}
+	for _, c := range s.capDrop {
+		caps = append(caps, "--cap-drop="+c)
+	}
+	return caps
 }
 
 func startCommandControlled(

--- a/pkg/util/fsutil/fsutil.go
+++ b/pkg/util/fsutil/fsutil.go
@@ -1178,8 +1178,8 @@ func ArchiveFiles(afname string,
 			}
 
 			defer close(f)
-			if _, err := io.Copy(tw, f); err != nil {
-				return err
+			if _, err := io.CopyN(tw, f, th.Size); err != nil {
+				return fmt.Errorf("cannot write %s file: %w", fname, err)
 			}
 		} else {
 			log.Errorf("fsutil.ArchiveFiles: bad file - %s", fname)


### PR DESCRIPTION
Sensor's artifacts folder contains "fat" (actually used files) and "slim" artifacts (the creport.json file, the events.json file, and, potentially, the sensor.log file). To ease retrieving the "slim" artifacts, sensor now dumps the "slim" artifacts into a tarball. Additionally, the commands.json file is saved too.
