### PR TITLE
fix: Make the artifacts folder flag impl complete

### DIFF
--- a/pkg/app/constants.go
+++ b/pkg/app/constants.go
@@ -1,6 +1,6 @@
 package app
 
 const (
-	DefaultArtifactDirPath = "/opt/dockerslim/artifacts"
-	ArtifactFilesDirName   = "files"
+	DefaultArtifactsDirPath = "/opt/dockerslim/artifacts"
+	ArtifactFilesDirName    = "files"
 )

--- a/pkg/app/master/inspectors/container/container_inspector.go
+++ b/pkg/app/master/inspectors/container/container_inspector.go
@@ -430,17 +430,17 @@ func (i *Inspector) RunContainer() error {
 		vm := dockerapi.HostMount{
 			Type:   "bind",
 			Source: artifactsPath,
-			Target: app.DefaultArtifactDirPath,
+			Target: app.DefaultArtifactsDirPath,
 		}
 
 		mkey := fmt.Sprintf("%s:%s:%s", vm.Type, vm.Source, vm.Target)
 		allMountsMap[mkey] = vm
 	} else {
-		//artifactsMountInfo = app.DefaultArtifactDirPath
+		//artifactsMountInfo = app.DefaultArtifactsDirPath
 		//configVolumes[artifactsMountInfo] = struct{}{}
 		vm := dockerapi.HostMount{
 			Type:   "volume",
-			Target: app.DefaultArtifactDirPath,
+			Target: app.DefaultArtifactsDirPath,
 		}
 
 		mkey := fmt.Sprintf("%s:%s:%s", vm.Type, vm.Source, vm.Target)
@@ -1124,7 +1124,7 @@ func (i *Inspector) ShutdownContainer() error {
 		}
 
 		reportLocalPath := filepath.Join(i.LocalVolumePath, ArtifactsDir, ReportArtifactTar)
-		reportRemotePath := filepath.Join(app.DefaultArtifactDirPath, report.DefaultContainerReportFileName)
+		reportRemotePath := filepath.Join(app.DefaultArtifactsDirPath, report.DefaultContainerReportFileName)
 		err := dockerutil.CopyFromContainer(i.APIClient, i.ContainerID, reportRemotePath, reportLocalPath, true, deleteOrig)
 		if err != nil {
 			errutil.FailOn(err)
@@ -1133,7 +1133,7 @@ func (i *Inspector) ShutdownContainer() error {
 		/*
 			//ALTERNATIVE WAY TO XFER THE FILE ARTIFACTS
 			filesOutLocalPath := filepath.Join(i.LocalVolumePath, ArtifactsDir, FileArtifactsArchiveTar)
-			filesTarRemotePath := filepath.Join(app.DefaultArtifactDirPath, fileArtifactsTar)
+			filesTarRemotePath := filepath.Join(app.DefaultArtifactsDirPath, fileArtifactsTar)
 			err = dockerutil.CopyFromContainer(i.APIClient,
 				i.ContainerID,
 				filesTarRemotePath,
@@ -1146,7 +1146,7 @@ func (i *Inspector) ShutdownContainer() error {
 		*/
 
 		filesOutLocalPath := filepath.Join(i.LocalVolumePath, ArtifactsDir, FileArtifactsOutTar)
-		filesRemotePath := filepath.Join(app.DefaultArtifactDirPath, app.ArtifactFilesDirName)
+		filesRemotePath := filepath.Join(app.DefaultArtifactsDirPath, app.ArtifactFilesDirName)
 		err = dockerutil.CopyFromContainer(i.APIClient, i.ContainerID, filesRemotePath, filesOutLocalPath, false, false)
 		if err != nil {
 			errutil.FailOn(err)

--- a/pkg/app/master/inspectors/pod/pod_inspector.go
+++ b/pkg/app/master/inspectors/pod/pod_inspector.go
@@ -229,7 +229,7 @@ func (i *Inspector) FinishMonitoring() {
 		i.pod.Namespace,
 		i.pod.Name,
 		i.workload.TargetContainer().Name,
-		filepath.Join(app.DefaultArtifactDirPath, report.DefaultContainerReportFileName),
+		filepath.Join(app.DefaultArtifactsDirPath, report.DefaultContainerReportFileName),
 		filepath.Join(i.imageInspector.ArtifactLocation, report.DefaultContainerReportFileName),
 	)
 	if err != nil {
@@ -242,7 +242,7 @@ func (i *Inspector) FinishMonitoring() {
 		i.pod.Namespace,
 		i.pod.Name,
 		i.workload.TargetContainer().Name,
-		filepath.Join(app.DefaultArtifactDirPath, app.ArtifactFilesDirName),
+		filepath.Join(app.DefaultArtifactsDirPath, app.ArtifactFilesDirName),
 		filepath.Join(i.imageInspector.ArtifactLocation, app.ArtifactFilesDirName+"/"),
 	)
 	if err != nil {
@@ -344,7 +344,7 @@ func (i *Inspector) prepareWorkload() error {
 		},
 		corev1.VolumeMount{
 			Name:      artifactsVolumeName,
-			MountPath: app.DefaultArtifactDirPath,
+			MountPath: app.DefaultArtifactsDirPath,
 		},
 	)
 

--- a/pkg/app/sensor/controlled/controlled.go
+++ b/pkg/app/sensor/controlled/controlled.go
@@ -127,6 +127,7 @@ func (s *Sensor) startMonitor(cmd *command.StartMonitor) (monitors.CompositeMoni
 		s.ctx,
 		cmd,
 		s.workDir,
+		s.artifactor.ArtifactsDir(),
 		s.mountPoint,
 		origPaths,
 		// TODO: Do we need to forward signals to the target app in the controlled mode?

--- a/pkg/app/sensor/controlled/controlled_test.go
+++ b/pkg/app/sensor/controlled/controlled_test.go
@@ -37,6 +37,7 @@ func newStubMonitorFunc(
 		ctx context.Context,
 		cmd *command.StartMonitor,
 		workDir string,
+		artifactsDir string,
 		mountPoint string,
 		origPaths map[string]struct{},
 		signalCh <-chan os.Signal,
@@ -53,6 +54,10 @@ func newStubMonitorFunc(
 type artifactorStub struct{}
 
 var _ artifacts.Artifactor = &artifactorStub{}
+
+func (a *artifactorStub) ArtifactsDir() string {
+	return ""
+}
 
 func (a *artifactorStub) GetCurrentPaths(root string, excludes []string) (map[string]struct{}, error) {
 	return map[string]struct{}{}, nil

--- a/pkg/app/sensor/standalone/standalone.go
+++ b/pkg/app/sensor/standalone/standalone.go
@@ -87,6 +87,7 @@ func (s *Sensor) Run() error {
 		s.ctx,
 		cmd,
 		s.workDir,
+		s.artifactor.ArtifactsDir(),
 		s.mountPoint,
 		origPaths,
 		initSignalForwardingChannel(s.ctx, s.stopSignal, s.stopGracePeriod),


### PR DESCRIPTION
app stdout and stderr log files wouldn't be included if the `--artifacts-dir` flag was used.

Also, unify the spelling: it's `artifactsDir` (plural) now everywhere, not `artifactDir` (singular).