### PR TITLE
fix: Sensor misses error check when walking container's fs

### DIFF
--- a/pkg/app/sensor/artifacts/artifacts.go
+++ b/pkg/app/sensor/artifacts/artifacts.go
@@ -245,6 +245,11 @@ func (a *artifactor) GetCurrentPaths(root string, excludes []string) (map[string
 				}
 			}
 
+			if err != nil {
+				log.Warnf("sensor: getCurrentPaths() - skipping %s with error: %v", pth, err)
+				return nil
+			}
+
 			if !(info.Mode().IsRegular() || (info.Mode()&os.ModeSymlink) != 0) {
 				//need symlinks too
 				return nil

--- a/pkg/imagebuilder/internalbuilder/engine.go
+++ b/pkg/imagebuilder/internalbuilder/engine.go
@@ -173,7 +173,7 @@ func (ref *Engine) Build(options imagebuilder.SimpleBuildOptions) error {
 			return err
 		}
 
-		log.Debug("DefaultSimpleBuilder.Build: pushed image to daemon - %s", imageLoadResponseStr)
+		log.Debugf("DefaultSimpleBuilder.Build: pushed image to daemon - %s", imageLoadResponseStr)
 		if ref.ShowBuildLogs {
 			//TBD (need execution context to display the build logs)
 		}


### PR DESCRIPTION
fstat() can fail for some of the entries making the file enumeration panic. This PR should make sensor warn instead.